### PR TITLE
feat: [P4PU-207] sidebar responsiveness

### DIFF
--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -9,9 +9,8 @@ import {
   Typography,
   useTheme,
   Tooltip,
-  Theme,
-  SxProps,
-  useMediaQuery
+  useMediaQuery,
+  type Theme
 } from '@mui/material';
 import { ISidebarMenuItem } from 'models/SidebarMenuItem';
 import { SidebarMenuItem } from './SidebarMenuItem';
@@ -22,13 +21,14 @@ import CloseIcon from '@mui/icons-material/Close';
 import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
 import ViewSidebarIcon from '@mui/icons-material/ViewSidebar';
 import useCollapseMenu from 'hooks/useCollapseMenu';
+import { sidebarStyles } from './sidebar.styles';
 
 export const Sidebar: React.FC = () => {
   const { t } = useTranslation();
   const theme = useTheme();
-  const lg = useMediaQuery(theme.breakpoints.up('lg'));
+  const lg = useMediaQuery((theme: Theme) => theme.breakpoints.up('lg'));
 
-  const { collapsed, changeMenuState } = useCollapseMenu(!lg);
+  const { collapsed, toggleCollapsed, setCollapsed } = useCollapseMenu(!lg);
   const overlay = !(lg || collapsed);
 
   const styles = sidebarStyles(theme, collapsed);
@@ -55,7 +55,7 @@ export const Sidebar: React.FC = () => {
 
   return (
     <>
-      <Box sx={styles.container}>
+      <Box sx={styles.container} component="aside">
         <Grid
           alignItems="normal"
           display="flex"
@@ -74,7 +74,7 @@ export const Sidebar: React.FC = () => {
                 <IconButton
                   data-testid="collapseClose"
                   aria-label={t(!collapsed ? 'sidebar.collapse' : 'sidebar.expand')}
-                  onClick={() => changeMenuState(collapsed)}
+                  onClick={toggleCollapsed}
                   size="large">
                   <CloseIcon />
                 </IconButton>
@@ -88,7 +88,7 @@ export const Sidebar: React.FC = () => {
             aria-label={t('menu.description')}>
             {menuItems.map((item, index) => (
               <SidebarMenuItem
-                onClick={() => !lg && changeMenuState(false)}
+                onClick={() => !lg && setCollapsed(true)}
                 collapsed={collapsed}
                 item={item}
                 key={index}
@@ -105,7 +105,7 @@ export const Sidebar: React.FC = () => {
                 <IconButton
                   data-testid="hamburgerButton"
                   aria-label={t(!collapsed ? 'sidebar.collapse' : 'sidebar.expand')}
-                  onClick={() => changeMenuState(collapsed)}
+                  onClick={toggleCollapsed}
                   size="large">
                   <MenuIcon />
                   {!lg && (
@@ -123,55 +123,3 @@ export const Sidebar: React.FC = () => {
     </>
   );
 };
-
-const sidebarStyles = (theme: Theme, collapsed: boolean): Record<string, SxProps> => ({
-  container: {
-    zIndex: collapsed ? 1 : 10,
-    position: collapsed ? 'relative' : 'fixed',
-    width: '100%',
-    top: 0,
-    height: '100%',
-    [theme.breakpoints.between('sm', 'lg')]: { width: collapsed ? '100%' : 'fit-content' },
-    [theme.breakpoints.up('lg')]: { width: 'fit-content', position: 'relative' },
-    [theme.breakpoints.down('lg')]: { height: collapsed ? 'fit-content' : '100%' }
-  },
-  nav: {
-    minHeight: collapsed ? '1vh' : '50vh',
-    height: '100%',
-    width: '100%',
-    bgcolor: 'background.paper',
-    [theme.breakpoints.up('sm')]: { width: collapsed ? '100%' : '300px' },
-    [theme.breakpoints.up('lg')]: { width: collapsed ? '88px' : '300px', minHeight: '50vh' }
-  },
-  overlay: {
-    bgcolor: 'rgba(23, 50, 77, 0.7)',
-    zIndex: 1,
-    position: 'fixed',
-    top: 0,
-    left: 0,
-    height: '100%',
-    width: '100%'
-  },
-  collapseIcon: {
-    textAlign: 'right',
-    pt: 1,
-    pr: 2
-  },
-  list: {
-    [theme.breakpoints.down('lg')]: { display: collapsed ? 'none' : 'inline-block' }
-  },
-  hamburgerBox: {
-    marginTop: 'auto',
-    [theme.breakpoints.down('lg')]: {
-      visibility: collapsed ? 'visible' : 'hidden',
-      marginTop: collapsed ? 0 : 'auto'
-    }
-  },
-  hamburgerIcon: {
-    p: 2
-  },
-  hamburgerTypography: {
-    fontWeight: 600,
-    pl: 1
-  }
-});

--- a/src/components/Sidebar/SidebarMenuItem.tsx
+++ b/src/components/Sidebar/SidebarMenuItem.tsx
@@ -18,39 +18,36 @@ function renderIcon(Icon: SvgIconComponent | (() => JSX.Element)) {
 export const SidebarMenuItem = ({ collapsed, item, onClick }: Props) => {
   const theme = useTheme();
 
-  function ListItemLink() {
-    return (
-      <ListItem disablePadding>
-        <ListItemButton
-          component={NavLink}
-          to={item.route}
-          onClick={onClick}
-          sx={{
-            px: 3,
-            '&.active': {
-              fontWeight: 'bold',
-              backgroundColor: alpha(theme.palette.primary.main, 0.08),
-              borderRight: '2px solid',
-              borderColor: theme.palette.primary.dark,
-              '.MuiTypography-root': {
-                fontWeight: 600,
-                color: theme.palette.primary.dark
-              },
-              '.MuiListItemIcon-root': {
-                color: theme.palette.primary.dark
-              }
+  return (
+    <ListItem disablePadding>
+      <ListItemButton
+        component={NavLink}
+        to={item.route}
+        onClick={onClick}
+        sx={{
+          px: 3,
+          '&.hover': {
+            backgroundColor: 'none'
+          },
+          '&.active': {
+            fontWeight: 'bold',
+            backgroundColor: alpha(theme.palette.primary.main, 0.08),
+            borderRight: '2px solid',
+            borderColor: theme.palette.primary.dark,
+            '.MuiTypography-root': {
+              fontWeight: 600,
+              color: theme.palette.primary.dark
+            },
+            '.MuiListItemIcon-root': {
+              color: theme.palette.primary.dark
             }
-          }}>
-          {item.icon && <ListItemIcon aria-hidden="true">{renderIcon(item.icon)}</ListItemIcon>}
-          {!collapsed && (
-            <ListItemText
-              id={`menu-item-${item.label.toLowerCase()}`}
-              primary={item.label}></ListItemText>
-          )}
-        </ListItemButton>
-      </ListItem>
-    );
-  }
-
-  return <ListItemLink />;
+          }
+        }}>
+        {item.icon && <ListItemIcon aria-hidden="true">{renderIcon(item.icon)}</ListItemIcon>}
+        {!collapsed && (
+          <ListItemText id={`menu-item-${item.label.toLowerCase()}`} primary={item.label} />
+        )}
+      </ListItemButton>
+    </ListItem>
+  );
 };

--- a/src/components/Sidebar/sidebar.styles.ts
+++ b/src/components/Sidebar/sidebar.styles.ts
@@ -1,0 +1,59 @@
+import { SxProps, Theme } from '@mui/material';
+
+export const sidebarStyles = (theme: Theme, collapsed: boolean): Record<string, SxProps> => ({
+  container: {
+    zIndex: collapsed ? 1 : 10,
+    position: collapsed ? 'relative' : 'fixed',
+    width: '100%',
+    top: 0,
+    height: '100%',
+    transition: 'width 0.3s ease, height 0.3s ease', // Add transition for smooth resizing
+    [theme.breakpoints.between('sm', 'lg')]: { width: collapsed ? '100%' : 'fit-content' },
+    [theme.breakpoints.up('lg')]: { width: 'fit-content', position: 'relative' },
+    [theme.breakpoints.down('lg')]: { height: collapsed ? 'fit-content' : '100%' }
+  },
+  nav: {
+    minHeight: collapsed ? '1vh' : '50vh',
+    height: '100%',
+    width: '100%',
+    bgcolor: 'background.paper',
+    transition: 'width 0.3s ease', // Add transition for smooth width change
+    [theme.breakpoints.up('sm')]: { width: collapsed ? '100%' : '300px' },
+    [theme.breakpoints.up('lg')]: { width: collapsed ? '88px' : '300px', minHeight: '50vh' }
+  },
+  overlay: {
+    bgcolor: 'rgba(23, 50, 77, 0.7)',
+    zIndex: 1,
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    height: '100%',
+    width: '100%'
+  },
+  collapseIcon: {
+    textAlign: 'right',
+    pt: 1,
+    pr: 2
+  },
+  list: {
+    [theme.breakpoints.down('lg')]: {
+      display: collapsed ? 'none' : 'inline-block'
+    }
+  },
+  hamburgerBox: {
+    marginTop: 'auto',
+    transition: 'opacity 0.3s ease', // Add transition for smooth visibility change
+    [theme.breakpoints.down('lg')]: {
+      marginTop: collapsed ? 0 : 'auto',
+      opacity: collapsed ? 1 : 0,
+      visibility: collapsed ? 'visible' : 'hidden'
+    }
+  },
+  hamburgerIcon: {
+    p: 2
+  },
+  hamburgerTypography: {
+    fontWeight: 600,
+    pl: 1
+  }
+});

--- a/src/components/Sidebar/sidebar.test.tsx
+++ b/src/components/Sidebar/sidebar.test.tsx
@@ -5,43 +5,100 @@ import '../../translations/i18n';
 import React from 'react';
 import Sidebar from './index';
 import i18n from '../../translations/i18n';
+import { theme } from '@pagopa/mui-italia';
+import { ThemeProvider } from '@mui/material';
+import useMediaQuery from '@mui/material/useMediaQuery';
 
 void i18n.init({
   resources: {}
 });
 
 const SidebarWithRouter = () => (
-  <MemoryRouter>
-    <Sidebar />
-  </MemoryRouter>
+  <ThemeProvider theme={theme}>
+    <MemoryRouter>
+      <Sidebar />
+    </MemoryRouter>
+  </ThemeProvider>
 );
 
+jest.mock('@mui/material/useMediaQuery', () => jest.fn());
+
 describe('Sidebar component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should render as expected', () => {
     render(<SidebarWithRouter />);
   });
 
-  test('renders with correct menu items', () => {
+  it('renders with correct menu items', () => {
     render(<SidebarWithRouter />);
 
     const hamburgerButton = screen.getByTestId('hamburgerButton');
 
     fireEvent.click(hamburgerButton);
     // Check if menu items are rendered
-    expect(screen.getByText('menu.homepage')).toBeTruthy();
-    expect(screen.getByText('menu.receipts')).toBeTruthy();
+    expect(screen.getByText('menu.homepage')).toBeInTheDocument();
+    expect(screen.getByText('menu.receipts')).toBeInTheDocument();
   });
 
-  test('toggles sidebar collapse/expand button is clicked', () => {
+  it('toggles sidebar collapse/expand button is clicked', () => {
     render(<SidebarWithRouter />);
 
     const hamburgerButton = screen.getByTestId('hamburgerButton');
-    expect(hamburgerButton).toBeTruthy();
+    expect(hamburgerButton).toBeInTheDocument();
 
     fireEvent.click(hamburgerButton);
-    expect(screen.getByText('menu.homepage')).toBeTruthy();
+    expect(screen.getByText('menu.homepage')).toBeInTheDocument();
 
     fireEvent.click(hamburgerButton);
-    expect(screen.queryByText('menu.homepage')).not.toBeTruthy();
+    expect(screen.queryByText('menu.homepage')).not.toBeInTheDocument();
+  });
+
+  it('renders with sidebar expanded on large screen', () => {
+    (useMediaQuery as jest.Mock).mockImplementation(() => true);
+    render(<SidebarWithRouter />);
+
+    expect(screen.getByLabelText('menu.navigationMenu')).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('renders with sidebar collapsed on small screen', () => {
+    (useMediaQuery as jest.Mock).mockImplementation(() => false);
+    render(<SidebarWithRouter />);
+
+    const hamburgerButton = screen.getByTestId('hamburgerButton');
+    fireEvent.click(hamburgerButton);
+    expect(screen.getByText('menu.homepage')).toBeInTheDocument();
+  });
+
+  it('renders close icon and handles click to collapse', () => {
+    (useMediaQuery as jest.Mock).mockImplementation(() => false);
+    render(<SidebarWithRouter />);
+
+    const hamburgerButton = screen.getByTestId('hamburgerButton');
+    fireEvent.click(hamburgerButton);
+
+    const closeIcon = screen.getByTestId('collapseClose');
+    expect(closeIcon).toBeInTheDocument();
+
+    fireEvent.click(closeIcon);
+
+    // Check if the sidebar is collapsed by verifying the absence of menu items
+    expect(screen.queryByText('menu.homepage')).not.toBeInTheDocument();
+  });
+
+  it('collapses when clicking on an item on lower resolutions', () => {
+    (useMediaQuery as jest.Mock).mockImplementation(() => false);
+    render(<SidebarWithRouter />);
+
+    const hamburgerButton = screen.getByTestId('hamburgerButton');
+    fireEvent.click(hamburgerButton);
+
+    const home = screen.getByText('menu.homepage');
+    fireEvent.click(home);
+
+    const navigationMenu = screen.getByLabelText('menu.navigationMenu');
+    expect(navigationMenu).toHaveAttribute('aria-expanded', 'false');
   });
 });

--- a/src/hooks/useCollapseMenu.test.tsx
+++ b/src/hooks/useCollapseMenu.test.tsx
@@ -1,19 +1,102 @@
-import '@testing-library/jest-dom';
-import { act, renderHook } from '@testing-library/react';
-import '../translations/i18n';
+import { renderHook } from '@testing-library/react';
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import useCollapseMenu from './useCollapseMenu';
 
-describe('useCollapseMenu hook', () => {
-  it('should return the inital menu status', () => {
+jest.mock('@mui/material/styles', () => ({
+  useTheme: jest.fn()
+}));
+
+jest.mock('@mui/material/useMediaQuery', () => jest.fn());
+
+describe('useCollapseMenu', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should initialize correctly', () => {
+    (useTheme as jest.Mock).mockReturnValue({
+      breakpoints: {
+        down: jest.fn().mockReturnValue(false)
+      }
+    });
+
+    (useMediaQuery as jest.Mock).mockReturnValue(false);
+
     const { result } = renderHook(() => useCollapseMenu(false));
+
     expect(result.current.collapsed).toBe(false);
   });
 
-  it('should change correctly the menu status state calling the useCollapseMenu function', () => {
-    const { result } = renderHook(() => useCollapseMenu(false));
-    act(() => {
-      result.current.changeMenuState(false);
+  it('should collapse menu when transitioning from above to below "lg" breakpoint', () => {
+    const mockBreakpointsDown = jest.fn();
+
+    (useTheme as jest.Mock).mockReturnValue({
+      breakpoints: {
+        down: mockBreakpointsDown
+      }
     });
+
+    (useMediaQuery as jest.Mock).mockReturnValue(false);
+
+    const { result, rerender } = renderHook(() => useCollapseMenu(false));
+
+    expect(result.current.collapsed).toBe(false);
+
+    // Change mock to simulate breakpoint transition
+    mockBreakpointsDown.mockReturnValue(true);
+    (useMediaQuery as jest.Mock).mockReturnValue(true);
+
+    // Re-render hook to apply changes
+    rerender();
+
     expect(result.current.collapsed).toBe(true);
+  });
+
+  it('should collapse menu when transitioning from below to above "lg" breakpoint', () => {
+    const mockBreakpointsDown = jest.fn();
+
+    (useTheme as jest.Mock).mockReturnValue({
+      breakpoints: {
+        down: mockBreakpointsDown
+      }
+    });
+
+    (useMediaQuery as jest.Mock).mockReturnValue(true);
+
+    const { result, rerender } = renderHook(() => useCollapseMenu(false));
+
+    expect(result.current.collapsed).toBe(false);
+
+    // Change mock to simulate breakpoint transition
+    mockBreakpointsDown.mockReturnValue(false);
+    (useMediaQuery as jest.Mock).mockReturnValue(false);
+
+    rerender();
+
+    expect(result.current.collapsed).toBe(false);
+  });
+
+  it('should not collapse menu when not transitioning above the "lg" breakpoint', () => {
+    const mockBreakpointsDown = jest.fn();
+
+    (useTheme as jest.Mock).mockReturnValue({
+      breakpoints: {
+        down: mockBreakpointsDown
+      }
+    });
+
+    (useMediaQuery as jest.Mock).mockReturnValue(false);
+
+    const { result, rerender } = renderHook(() => useCollapseMenu(false));
+
+    expect(result.current.collapsed).toBe(false);
+
+    mockBreakpointsDown.mockReturnValue(false);
+    (useMediaQuery as jest.Mock).mockReturnValue(false);
+
+    rerender();
+
+    expect(result.current.collapsed).toBe(false);
   });
 });

--- a/src/hooks/useCollapseMenu.tsx
+++ b/src/hooks/useCollapseMenu.tsx
@@ -1,12 +1,28 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
 
 function useCollapseMenu(initialCollapsedState: boolean) {
   const [collapsed, setCollapsed] = useState<boolean>(initialCollapsedState);
+  const theme = useTheme();
+  const isBelowLg = useMediaQuery(theme.breakpoints.down('lg'));
+  const [wasBelowLg, setWasBelowLg] = useState(isBelowLg);
 
-  const changeMenuState = (collapsed: boolean) => setCollapsed(!collapsed);
+  const toggleCollapsed = () => setCollapsed(!collapsed);
+
+  useEffect(() => {
+    if (isBelowLg && !wasBelowLg) {
+      setCollapsed(true);
+    } else if (!isBelowLg && wasBelowLg) {
+      setCollapsed(false);
+    }
+    setWasBelowLg(isBelowLg);
+  }, [isBelowLg]);
+
   return {
     collapsed,
-    changeMenuState
+    setCollapsed,
+    toggleCollapsed
   };
 }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- moved sidebar styles in its own file
- sidebar collapse/expand transitions
- useCollapseMenu refactoring
- useCollapseMenu state changes when crossing lg(1200px) threshold
- unit tests
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This pr tries to improves sidebar responsiveness. The previous useCollapseMenu behavior was to keep the current state when changing resolutions resulting in a weird user experience.
Also some transition animation was added to decrease ui jank when crossing resolution threshold.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- visual testing
- unit tests

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
