### PR TITLE
feat: [P4PU-341] Redirect on PaymentNotice mismatch

### DIFF
--- a/src/components/PaymentNotice/Detail.test.tsx
+++ b/src/components/PaymentNotice/Detail.test.tsx
@@ -3,13 +3,18 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { useTranslation } from 'react-i18next';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
-import { _Detail } from './Detail';
 import { mockNotice } from 'stories/utils/PaymentNoticeMocks';
 import { PaymentNoticeEnum, PaymentNoticeMultipleType } from 'models/PaymentNotice';
+import { PaymentNotice } from './PaymentNotice';
 
 jest.mock('react-i18next', () => ({
   ...jest.requireActual('react-i18next'),
   useTranslation: jest.fn()
+}));
+
+jest.mock('@preact/signals-react', () => ({
+  signal: jest.fn(),
+  effect: jest.fn()
 }));
 
 describe('Detail Component', () => {
@@ -25,7 +30,7 @@ describe('Detail Component', () => {
   });
 
   it('renders the single notice data', () => {
-    renderWithTheme(<_Detail paymentNotice={mockNotice} />);
+    renderWithTheme(<PaymentNotice.Detail paymentNotice={mockNotice} />);
 
     expect(screen.getByText(mockNotice.iupd)).toBeInTheDocument();
     expect(screen.getByText(mockNotice.debtorFullName)).toBeInTheDocument();
@@ -36,7 +41,7 @@ describe('Detail Component', () => {
 
   it('does not render multiple notice data', () => {
     renderWithTheme(
-      <_Detail
+      <PaymentNotice.Detail
         paymentNotice={
           {
             ...mockNotice,

--- a/src/components/PaymentNotice/Empty.test.tsx
+++ b/src/components/PaymentNotice/Empty.test.tsx
@@ -2,12 +2,17 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { PaymentNotice } from './index';
 import i18n from 'translations/i18n';
-import { _Empty } from './Empty';
 
 void i18n.init({
   resources: {}
 });
+
+jest.mock('@preact/signals-react', () => ({
+  signal: jest.fn(),
+  effect: jest.fn()
+}));
 
 jest.mock('@pagopa/mui-italia', () => ({
   IllusSharingInfo: jest.fn(() => <div>Illustration</div>)
@@ -20,7 +25,7 @@ describe('PaymentNotice.Empty Component', () => {
   };
 
   it('renders the button', () => {
-    renderWithTheme(<_Empty />);
+    renderWithTheme(<PaymentNotice.Empty />);
 
     expect(screen.getByRole('link')).toBeInTheDocument();
   });

--- a/src/components/PaymentNotice/Info.test.tsx
+++ b/src/components/PaymentNotice/Info.test.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { _Info } from './Info';
+import { PaymentNotice } from './PaymentNotice';
+
+jest.mock('@preact/signals-react', () => ({
+  signal: jest.fn(),
+  effect: jest.fn()
+}));
 
 describe('Payment notices info component', () => {
   it('should render as expected', () => {
-    render(<_Info />);
+    render(<PaymentNotice.Info />);
   });
 });

--- a/src/components/PaymentNotice/Preview.test.tsx
+++ b/src/components/PaymentNotice/Preview.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { PaymentNotice } from './index';
 import i18n from 'translations/i18n';
-import { _Preview } from './Preview';
 
 void i18n.init({
   resources: {}
@@ -13,6 +13,11 @@ jest.mock('@pagopa/mui-italia', () => ({
   IllusSharingInfo: jest.fn(() => <div>Illustration</div>)
 }));
 
+jest.mock('@preact/signals-react', () => ({
+  signal: jest.fn(),
+  effect: jest.fn()
+}));
+
 describe('PaymentNotice.Preview Component', () => {
   const renderWithTheme = (ui: React.ReactElement) => {
     const theme = createTheme();
@@ -20,20 +25,20 @@ describe('PaymentNotice.Preview Component', () => {
   };
 
   it('renders the title and description', () => {
-    renderWithTheme(<_Preview />);
+    renderWithTheme(<PaymentNotice.Preview />);
 
     expect(screen.getByText('app.paymentNotice.preview.title')).toBeInTheDocument();
     expect(screen.getByText('app.paymentNotice.preview.description')).toBeInTheDocument();
   });
 
   it('renders the action button', () => {
-    renderWithTheme(<_Preview />);
+    renderWithTheme(<PaymentNotice.Preview />);
 
     expect(screen.getByText('app.paymentNotice.preview.action')).toBeInTheDocument();
   });
 
   it('renders the illustration on large screens', () => {
-    renderWithTheme(<_Preview />);
+    renderWithTheme(<PaymentNotice.Preview />);
 
     // Simulate a large screen
     window.matchMedia = jest.fn().mockImplementation((query) => ({
@@ -44,7 +49,7 @@ describe('PaymentNotice.Preview Component', () => {
       removeListener: jest.fn()
     }));
 
-    renderWithTheme(<_Preview />);
+    renderWithTheme(<PaymentNotice.Preview />);
 
     expect(screen.getByText('Illustration')).toBeInTheDocument();
   });
@@ -59,7 +64,7 @@ describe('PaymentNotice.Preview Component', () => {
       removeListener: jest.fn()
     }));
 
-    renderWithTheme(<_Preview />);
+    renderWithTheme(<PaymentNotice.Preview />);
 
     expect(screen.queryByText('Illustration')).not.toBeInTheDocument();
   });

--- a/src/hooks/useNormalizedNotices.test.tsx
+++ b/src/hooks/useNormalizedNotices.test.tsx
@@ -1,0 +1,46 @@
+import { renderHook } from '@testing-library/react';
+import utils from 'utils';
+import converters from 'utils/converters';
+import { useNormalizedNotices } from './useNormalizedNotices';
+
+jest.mock('utils', () => ({
+  loaders: {
+    getPaymentNotices: jest.fn()
+  }
+}));
+
+jest.mock('utils/converters', () => ({
+  prepareNoticesData: jest.fn()
+}));
+
+describe('useNormalizedNotices', () => {
+  beforeEach(() => {
+    (utils.loaders.getPaymentNotices as jest.Mock).mockClear();
+    (converters.prepareNoticesData as jest.Mock).mockClear();
+  });
+
+  it('should return normalized notices', () => {
+    // Arrange
+    const mockQueryResult = {
+      data: [
+        { id: 1, notice: 'Notice 1' },
+        { id: 2, notice: 'Notice 2' }
+      ]
+    };
+    const mockNormalizedData = [
+      { id: 1, normalizedNotice: 'Normalized Notice 1' },
+      { id: 2, normalizedNotice: 'Normalized Notice 2' }
+    ];
+
+    (utils.loaders.getPaymentNotices as jest.Mock).mockReturnValue(mockQueryResult);
+    (converters.prepareNoticesData as jest.Mock).mockReturnValue(mockNormalizedData);
+
+    // Act
+    const { result } = renderHook(() => useNormalizedNotices());
+
+    // Assert
+    expect(utils.loaders.getPaymentNotices).toHaveBeenCalledTimes(1);
+    expect(converters.prepareNoticesData).toHaveBeenCalledWith(mockQueryResult.data);
+    expect(result.current).toEqual({ ...mockQueryResult, data: mockNormalizedData });
+  });
+});

--- a/src/hooks/usePersistentSignal.test.ts
+++ b/src/hooks/usePersistentSignal.test.ts
@@ -1,0 +1,62 @@
+import { renderHook, act } from '@testing-library/react';
+import { effect, signal } from '@preact/signals-react';
+import { usePersistentSignal } from './usePersistentSignal';
+
+jest.mock('@preact/signals-react', () => ({
+  effect: jest.fn(),
+  signal: jest.fn()
+}));
+
+describe('usePersistentSignal', () => {
+  let mockSignal: { value: unknown };
+  let mockEffectCleanup;
+
+  beforeEach(() => {
+    mockSignal = { value: undefined };
+    jest.spyOn(window.localStorage.__proto__, 'getItem').mockClear();
+    jest.spyOn(window.localStorage.__proto__, 'setItem').mockClear();
+    jest.spyOn(window.localStorage.__proto__, 'removeItem').mockClear();
+
+    (signal as jest.Mock).mockImplementation(() => mockSignal);
+    (effect as jest.Mock).mockImplementation((callback) => {
+      mockEffectCleanup = callback();
+      return mockEffectCleanup;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should initialize with the value from localStorage', () => {
+    const key = 'testKey';
+    const storedValue = { foo: 'bar' };
+    localStorage.setItem(key, JSON.stringify(storedValue));
+
+    renderHook(() => usePersistentSignal(key));
+
+    expect(localStorage.getItem).toHaveBeenCalledWith(key);
+    expect(signal).toHaveBeenCalledWith(storedValue);
+  });
+
+  it('should initialize with the default value if no value in localStorage', () => {
+    const key = 'testKey';
+    const defaultValue = { foo: 'bar' };
+
+    renderHook(() => usePersistentSignal(key, defaultValue));
+
+    expect(localStorage.getItem).toHaveBeenCalledWith(key);
+    expect(signal).toHaveBeenCalledWith(defaultValue);
+  });
+
+  it('should remove the item from localStorage when removeItem is called', () => {
+    const key = 'testKey';
+    const { result } = renderHook(() => usePersistentSignal(key));
+
+    act(() => {
+      result.current.removeItem();
+    });
+
+    expect(localStorage.removeItem).toHaveBeenCalledWith(key);
+  });
+});

--- a/src/hooks/usePersistentSignal.ts
+++ b/src/hooks/usePersistentSignal.ts
@@ -17,7 +17,10 @@ export function usePersistentSignal<T>(key: string, initialValue?: T) {
 
   const state = signal<T>(getStoredValue());
 
-  // Sync state with localStorage
+  const removeItem = () => {
+    localStorage.removeItem(key);
+  };
+
   effect(() => {
     if (state.value) {
       try {
@@ -28,5 +31,5 @@ export function usePersistentSignal<T>(key: string, initialValue?: T) {
     }
   });
 
-  return state;
+  return { state, removeItem };
 }

--- a/src/routes/PaymentNoticeDetail.tsx
+++ b/src/routes/PaymentNoticeDetail.tsx
@@ -1,15 +1,21 @@
 import React from 'react';
 import { PaymentNotice } from 'components/PaymentNotice';
 import { useStore } from 'store/GlobalStore';
+import { Navigate, useParams } from 'react-router-dom';
+import { ArcRoutes } from './routes';
+import { paymentNoticeState } from 'store/PaymentNoticeStore';
 
 export default function PaymentNoticeDetail() {
   const {
     state: { paymentNotice }
   } = useStore();
 
-  return (
-    <>
-      <PaymentNotice.Detail paymentNotice={paymentNotice} />
-    </>
-  );
+  const { id } = useParams();
+
+  if (!paymentNotice || paymentNotice.iupd !== id) {
+    paymentNoticeState.removeItem();
+    return <Navigate to={ArcRoutes.PAYMENT_NOTICES} />;
+  }
+
+  return <PaymentNotice.Detail paymentNotice={paymentNotice} />;
 }

--- a/src/store/GlobalStore.tsx
+++ b/src/store/GlobalStore.tsx
@@ -7,7 +7,7 @@ const StoreContext = createContext<StoreContextProps | undefined>(undefined);
 
 export const StoreProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const combinedState: State = {
-    [STATE.PAYMENT_NOTICE]: paymentNoticeState?.value
+    [STATE.PAYMENT_NOTICE]: paymentNoticeState.state.value
   };
 
   const setState = (key: STATE, value: unknown) => {

--- a/src/store/PaymentNoticeStore.tsx
+++ b/src/store/PaymentNoticeStore.tsx
@@ -9,5 +9,5 @@ export const paymentNoticeState = usePersistentSignal<PaymentNoticeType | undefi
 
 // Function to update the payment notice
 export function setPaymentNotice(notice: PaymentNoticeType | undefined) {
-  paymentNoticeState.value = notice;
+  paymentNoticeState.state.value = notice;
 }

--- a/src/store/globalStore.test.tsx
+++ b/src/store/globalStore.test.tsx
@@ -6,7 +6,7 @@ import { StoreProvider, useStore } from './GlobalStore';
 
 // Mock the external dependencies
 jest.mock('./PaymentNoticeStore', () => ({
-  paymentNoticeState: { value: { id: 1, debtorFullName: 'Test notice' } },
+  paymentNoticeState: { state: { value: { id: 1, debtorFullName: 'Test notice' } } },
   setPaymentNotice: jest.fn()
 }));
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
With this PR landing on /payment-notice/:`id` redirect to /payment-notices if `id` is not equal to the notice `iupd`.
Moreover, the stored PaymentNotice is removed from `localStorage` if this situation occurs.  
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Before this changes the last stored PayementNotice was rendered with any id value to /payment-notices/:id
#### How Has This Been Tested?
- visual testing
- unit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
