### PR TITLE
feat: [P4PU-396] Opening assistance's form in a new browser's tab

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -5,7 +5,7 @@ import { Footer } from './Footer';
 import { Sidebar } from './Sidebar/Sidebar';
 import Breadcrumbs from './Breadcrumbs/Breadcrumbs';
 import { NavigateNext } from '@mui/icons-material';
-import { Outlet, ScrollRestoration, useMatches, useNavigate } from 'react-router-dom';
+import { Outlet, ScrollRestoration, useMatches } from 'react-router-dom';
 import { RouteHandleObject } from 'models/Breadcrumbs';
 import { Header } from './Header';
 import { BackButton } from './BackButton';
@@ -33,7 +33,6 @@ export function Layout() {
   } as RouteHandleObject;
 
   const sidePadding = sidebar.visible ? 3 : { xs: 3, md: 12, lg: 27, xl: 34 };
-  const navigate = useNavigate();
 
   return (
     <>
@@ -49,11 +48,7 @@ export function Layout() {
           flexDirection="column"
           flexWrap={'nowrap'}>
           <Grid flexBasis={{ xs: 'fit-content' }} item xs={12} height="fit-content">
-            <Header
-              onAssistanceClick={() => {
-                navigate(ArcRoutes.ASSISTANCE);
-              }}
-            />
+            <Header onAssistanceClick={() => window.open(ArcRoutes.ASSISTANCE, '_blank')} />
           </Grid>
           <Grid
             item


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Adding '_blank' parameter to window.open function to open assistance page in a new browser's tab

<!--- Describe your changes in detail -->

#### Motivation and Context
This is required because the assistance experience (managed externally by Zendesk) doesn't allow a return to the calling Front End. This improves the UX

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested manually using the local development server

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
