### PR TITLE
fix: [P4PU-444] Sidebar button homepage "always on"

### DIFF
--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -41,7 +41,8 @@ export const Sidebar: React.FC = () => {
     {
       label: t('menu.homepage'),
       icon: ViewSidebarIcon,
-      route: ArcRoutes.DASHBOARD
+      route: ArcRoutes.DASHBOARD,
+      end: true
     },
     {
       label: t('menu.paymentNotices'),

--- a/src/components/Sidebar/SidebarMenuItem.tsx
+++ b/src/components/Sidebar/SidebarMenuItem.tsx
@@ -21,6 +21,7 @@ export const SidebarMenuItem = ({ collapsed, item, onClick }: Props) => {
   return (
     <ListItem disablePadding>
       <ListItemButton
+        end={item.end || false}
         component={NavLink}
         to={item.route}
         onClick={onClick}

--- a/src/models/SidebarMenuItem.ts
+++ b/src/models/SidebarMenuItem.ts
@@ -4,4 +4,7 @@ export interface ISidebarMenuItem {
   label: string;
   icon?: SvgIconComponent | (() => JSX.Element);
   route: string;
+  /* The end prop changes the matching logic for the active and pending states to only match to the "end" of the NavLink's to path.
+  If the URL is longer than to, it will no longer be considered active. */
+  end?: boolean;
 }


### PR DESCRIPTION
This PR solve the issue: Sidebar button homepage "always on"

#### List of Changes

- Add "end attribute" to manage when we want a button selected only in an exact path (es Homepage)

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
