### PR TITLE
fix: [P4PU-349] signals unmocked and tested

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@mui/lab": "^5.0.0-alpha.170",
     "@mui/material": "^5.15.15",
     "@pagopa/mui-italia": "^1.3.0",
-    "@preact/signals-react": "^2.1.0",
+    "@preact/signals-react": "^2.2.0",
     "@tanstack/react-query": "^5.40.0",
     "axios": "^1.6.8",
     "i18next": "^23.10.1",

--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -28,11 +28,6 @@ vi.mock('./utils/config', () => ({
   product: 'Product Name'
 }));
 
-vi.mock('@preact/signals-react', () => ({
-  signal: vi.fn(),
-  effect: vi.fn()
-}));
-
 const WrappedHeader = (props: HeaderProps) => {
   const queryClient = new QueryClient();
   return (

--- a/src/components/PaymentNotice/Detail.test.tsx
+++ b/src/components/PaymentNotice/Detail.test.tsx
@@ -12,11 +12,6 @@ i18nTestSetup({});
 
 const queryClient = new QueryClient();
 
-vi.mock('@preact/signals-react', () => ({
-  signal: vi.fn(),
-  effect: vi.fn()
-}));
-
 describe('Detail Component', () => {
   const renderWithTheme = (ui: React.ReactElement) => {
     const theme = createTheme();

--- a/src/components/PaymentNotice/Empty.test.tsx
+++ b/src/components/PaymentNotice/Empty.test.tsx
@@ -7,11 +7,6 @@ import { i18nTestSetup } from '__tests__/i18nTestSetup';
 
 i18nTestSetup({});
 
-vi.mock('@preact/signals-react', () => ({
-  signal: vi.fn(),
-  effect: vi.fn()
-}));
-
 describe('PaymentNotice.Empty Component', () => {
   const renderWithTheme = (ui: React.ReactElement) => {
     const theme = createTheme();

--- a/src/components/PaymentNotice/Info.test.tsx
+++ b/src/components/PaymentNotice/Info.test.tsx
@@ -2,11 +2,6 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { PaymentNotice } from './PaymentNotice';
 
-vi.mock('@preact/signals-react', () => ({
-  signal: vi.fn(),
-  effect: vi.fn()
-}));
-
 describe('Payment notices info component', () => {
   it('should render as expected', () => {
     render(<PaymentNotice.Info />);

--- a/src/components/PaymentNotice/Preview.test.tsx
+++ b/src/components/PaymentNotice/Preview.test.tsx
@@ -16,11 +16,6 @@ vi.mock('@pagopa/mui-italia', async () => {
   };
 });
 
-vi.mock('@preact/signals-react', () => ({
-  signal: vi.fn(),
-  effect: vi.fn()
-}));
-
 describe('PaymentNotice.Preview Component', () => {
   const renderWithTheme = (ui: React.ReactElement) => {
     const theme = createTheme();

--- a/src/routes/PaymentNotices/PaymentNotices.test.tsx
+++ b/src/routes/PaymentNotices/PaymentNotices.test.tsx
@@ -18,10 +18,6 @@ vi.mock(import('@mui/material'), async (importActual) => ({
 vi.mock('utils/loaders');
 vi.mock('utils/converters');
 
-vi.mock(import('@preact/signals-react'), async (importOriginal) => ({
-  ...(await importOriginal())
-}));
-
 vi.mock('./store/PaymentNoticeStore', () => ({
   paymentNoticeState: { removeItem: vi.fn(), state: null }
 }));

--- a/src/store/PaymentNoticeStore.test.tsx
+++ b/src/store/PaymentNoticeStore.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+import { PaymentNoticeType } from 'models/PaymentNotice';
+import { setPaymentNotice, paymentNoticeState } from './PaymentNoticeStore';
+
+// Mock the usePersistentSignal hook
+vi.mock('hooks/usePersistentSignal', () => ({
+  usePersistentSignal: vi.fn(() => ({
+    state: { value: undefined }
+  }))
+}));
+
+describe('setPaymentNotice', () => {
+  it('should update the payment notice state', () => {
+    const mockNotice: PaymentNoticeType = {
+      iupd: '1',
+      debtorFullName: 'Test notice'
+    } as unknown as PaymentNoticeType;
+
+    // Call the function
+    setPaymentNotice(mockNotice);
+
+    // Assert that the state is updated correctly
+    expect(paymentNoticeState.state.value).toBe(mockNotice);
+  });
+
+  it('should set the payment notice state to undefined', () => {
+    // Call the function with undefined
+    setPaymentNotice(undefined);
+
+    // Assert that the state is updated to undefined
+    expect(paymentNoticeState.state.value).toBeUndefined();
+  });
+});

--- a/src/store/UserInfoStore.test.ts
+++ b/src/store/UserInfoStore.test.ts
@@ -1,0 +1,40 @@
+import { UserMemo } from 'models/User';
+import { vi } from 'vitest';
+import { setUserInfo, userInfoState } from './UserInfoStore';
+
+// Mock sessionStorage
+beforeEach(() => {
+  vi.spyOn(window.sessionStorage, 'setItem');
+  vi.spyOn(window.sessionStorage, 'getItem').mockReturnValue(null); // Initially sessionStorage returns null
+});
+
+afterEach(() => {
+  vi.clearAllMocks(); // Clear mocks after each test to avoid test interference
+});
+
+// Mock usePersistentSignal
+vi.mock('hooks/usePersistentSignal', () => ({
+  usePersistentSignal: vi.fn().mockImplementation(() => ({
+    state: {
+      value: undefined
+    }
+  }))
+}));
+
+describe('setUserInfo', () => {
+  it('should set user info in persistent state', () => {
+    const user: UserMemo = { id: '123', name: 'John Doe' } as unknown as UserMemo;
+
+    setUserInfo(user);
+
+    // Check that userInfoState state value is updated
+    expect(userInfoState.state.value).toEqual(user);
+  });
+
+  it('should reset user info to undefined', () => {
+    setUserInfo(undefined);
+
+    // Check that userInfoState state value is reset
+    expect(userInfoState.state.value).toBeUndefined();
+  });
+});

--- a/src/store/globalStore.test.tsx
+++ b/src/store/globalStore.test.tsx
@@ -6,11 +6,6 @@ import { StoreProvider, useStore } from './GlobalStore';
 import { setPaymentNotice } from './PaymentNoticeStore';
 import { setUserInfo } from './UserInfoStore';
 
-vi.mock('@preact/signals-react', () => ({
-  signal: vi.fn(),
-  effect: vi.fn()
-}));
-
 // Mock the external dependencies
 vi.mock('./PaymentNoticeStore', () => ({
   paymentNoticeState: { state: { value: { id: 1, debtorFullName: 'Test notice' } } },

--- a/src/utils/loaders.test.tsx
+++ b/src/utils/loaders.test.tsx
@@ -38,11 +38,6 @@ vi.mock('./utils', () => {
   };
 });
 
-vi.mock('@preact/signals-react', () => ({
-  signal: vi.fn(),
-  effect: vi.fn()
-}));
-
 describe('api loaders', () => {
   const queryClient = new QueryClient();
   const wrapper = ({ children }: { children: ReactNode }) => (

--- a/vitest.setup.mts
+++ b/vitest.setup.mts
@@ -1,14 +1,3 @@
-import { vi } from 'vitest';
 import { i18nTestSetup } from './src/__tests__/i18nTestSetup';
 
 i18nTestSetup({});
-
-vi.mock('@preact/signals-react', () => {
-  return {
-    __esModule: true,
-    signal: vi.fn().mockImplementation(() => {
-      return {};
-    }),
-  };
-});
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -3956,15 +3956,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@preact/signals-react@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@preact/signals-react@npm:2.1.0"
+"@preact/signals-react@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@preact/signals-react@npm:2.2.0"
   dependencies:
     "@preact/signals-core": "npm:^1.7.0"
     use-sync-external-store: "npm:^1.2.0"
   peerDependencies:
     react: ^16.14.0 || 17.x || 18.x
-  checksum: 10c0/82c455a54af4c80ef281ab816afa39fc2c59fcbc0edc851c424004e8590386783001c368df5d3883278783e9769ece4d19f0969992dae70f8eaaba4cacbdfd94
+  checksum: 10c0/dcf37d9784d2ecbdfcbfbd2a911ec7faf30243c2eecb3f4111de4cf959f32f2ff7ca9c81abe7489652f130a8d6571dc28193dd4fae98b403c203461009c59fec
   languageName: node
   linkType: hard
 
@@ -12336,7 +12336,7 @@ __metadata:
     "@mui/lab": "npm:^5.0.0-alpha.170"
     "@mui/material": "npm:^5.15.15"
     "@pagopa/mui-italia": "npm:^1.3.0"
-    "@preact/signals-react": "npm:^2.1.0"
+    "@preact/signals-react": "npm:^2.2.0"
     "@storybook/addon-essentials": "npm:8.1.11"
     "@storybook/addon-interactions": "npm:8.1.11"
     "@storybook/addon-links": "npm:8.1.11"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- removes vitest setup signal mocking
- removes signals  mocks where superflous
- increases store provider coverage
- signals library dependency upgraded

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Using vitest and the latest version of @preact/signals, the library mock is not needed anymore
#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit testing
#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
