### PR TITLE
fix: [P4PU-565] back from notice detail, retry on error and paymentNotice SessionStorage clearing

### DIFF
--- a/src/components/PaymentNotice/Card.tsx
+++ b/src/components/PaymentNotice/Card.tsx
@@ -41,7 +41,8 @@ export const _Card = (notice: PaymentNoticeType) => {
   const navigate = useNavigate();
   const { setState } = useStore();
 
-  function viewDetail() {
+  function viewDetail(e: React.MouseEvent) {
+    e.stopPropagation();
     setState(STATE.PAYMENT_NOTICE, notice);
     navigate(`${ArcRoutes.PAYMENT_NOTICES}${iupd}`);
   }
@@ -51,7 +52,7 @@ export const _Card = (notice: PaymentNoticeType) => {
       <Stack
         role="option"
         component="article"
-        onClick={() => viewDetail()}
+        onClick={viewDetail}
         borderRadius={1}
         padding={3}
         gap={3}
@@ -80,7 +81,7 @@ export const _Card = (notice: PaymentNoticeType) => {
               />
             </Stack>
           )}
-          <IconButton aria-label={t('app.paymentNotice.card.detail')} onClick={() => viewDetail()}>
+          <IconButton aria-label={t('app.paymentNotice.card.detail')} onClick={viewDetail}>
             <ArrowForwardIosIcon color="primary" fontSize="small" />
           </IconButton>
         </Stack>

--- a/src/components/PaymentNotice/Error.test.tsx
+++ b/src/components/PaymentNotice/Error.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PaymentNotice } from './PaymentNotice';
+
+describe('Payment notices error component', () => {
+  const onRetry = vi.fn();
+
+  it('should render as expected', () => {
+    render(<PaymentNotice.Error onRetry={onRetry} />);
+    const button = screen.getByRole('button', { name: 'app.paymentNotice.error.button' });
+    expect(button).toBeVisible();
+    const description = screen.getByText('app.paymentNotice.error.description');
+    expect(description).toBeVisible();
+  });
+
+  it('should trigger the retry function correctly', () => {
+    const onRetry = vi.fn();
+    render(<PaymentNotice.Error onRetry={onRetry} />);
+    const button = screen.getByRole('button', { name: 'app.paymentNotice.error.button' });
+    fireEvent.click(button);
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/PaymentNotice/Error.tsx
+++ b/src/components/PaymentNotice/Error.tsx
@@ -5,6 +5,10 @@ import { useTranslation } from 'react-i18next';
 import { Box, Button, Card, CardActions } from '@mui/material';
 import { ErrorOutline } from '@mui/icons-material';
 
+interface ErrorProps {
+  onRetry: () => void;
+}
+
 /**
  * This component is considered private and should not be used directly.
  * Instead, use `PaymentNotice.Error` for rendering the card.
@@ -12,7 +16,7 @@ import { ErrorOutline } from '@mui/icons-material';
  * @component
  * @private
  */
-export const _Error = () => {
+export const _Error = (props: ErrorProps) => {
   const { t } = useTranslation();
   return (
     <Card
@@ -26,6 +30,7 @@ export const _Error = () => {
           <Typography variant="body1">{t('app.paymentNotice.error.description')}</Typography>
           <Box mt={3} width={'100%'}>
             <Button
+              onClick={props.onRetry}
               variant="text"
               aria-label={t('app.paymentNotice.error.button')}
               role="button"

--- a/src/routes/PaymentNotices/index.tsx
+++ b/src/routes/PaymentNotices/index.tsx
@@ -1,18 +1,25 @@
+import React, { useEffect } from 'react';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { PaymentNotice } from 'components/PaymentNotice';
 import QueryLoader from 'components/QueryLoader';
 import { PaymentNoticesListSkeleton } from 'components/Skeleton';
 import { useNormalizedNotices } from 'hooks/useNormalizedNotices';
-import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useStore } from 'store/GlobalStore';
+import { STATE } from 'store/types';
 import utils from 'utils';
 
 const Notices = () => {
-  const { data, isError } = useNormalizedNotices();
+  const { data, isError, refetch } = useNormalizedNotices();
+  const { setState } = useStore();
+
+  useEffect(() => {
+    setState(STATE.PAYMENT_NOTICE, {});
+  }, []);
 
   const Content = () => {
-    if (isError || !data) return <PaymentNotice.Error />;
+    if (isError || !data) return <PaymentNotice.Error onRetry={refetch} />;
     if (!data?.paymentNotices?.length) return <PaymentNotice.Empty />;
     return (
       <Stack gap={5} component="section">

--- a/vitest.setup.mts
+++ b/vitest.setup.mts
@@ -1,3 +1,4 @@
 import { i18nTestSetup } from './src/__tests__/i18nTestSetup';
+import '@testing-library/jest-dom';
 
 i18nTestSetup({});


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. Adding a e.stopPropagation to avoid a multiple calling to navigate (fix the problem about the necessity to click two times back to return to the list from the detail notice page)
2. Adding a retry function (missing) to the retry button on payment notices page
3. Clearing the SessionStorage item paymentNotice on payment notices page return (no need to keep data outside the scope of the detail page)

<!--- Describe your changes in detail -->

#### Motivation and Context
Writing E2E test about the list and detail notice page these have been discovered and fixed with this PR to make E2E test run successfully

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Manually trying to replicate the problems and running the relative E2E test (locally)

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.