### PR TITLE
feat: [P4PU-586] Unhappy path for login flow

### DIFF
--- a/.proxyrc
+++ b/.proxyrc
@@ -1,11 +1,4 @@
 {
-  "/api/token/oneidentity": {
-    "target": "http://localhost:8080",
-    "logLevel": "debug",
-    "pathRewrite": {
-      "^/api": ""
-    }
-  },
   "/api/**": {
     "target": "https://api.dev.cittadini.pagopa.it/arc/v1",
     "changeOrigin": true,

--- a/src/routes/AuthCallback/index.tsx
+++ b/src/routes/AuthCallback/index.tsx
@@ -3,13 +3,21 @@ import { useLoaderData } from 'react-router-dom';
 import { ArcRoutes } from '../routes';
 import { TokenResponse } from '../../../generated/data-contracts';
 import { Box, CircularProgress } from '@mui/material';
+import { tokenResponseSchema } from '../../../generated/zod-schema';
 
 export default function AuthCallback() {
-  const result = useLoaderData() as TokenResponse | null;
-  if (result) {
+  const result = useLoaderData() as TokenResponse | number;
+  const checkToken = tokenResponseSchema.safeParse(result);
+
+  if (checkToken.success) {
+    // if we have a formal token
     window.localStorage.setItem('accessToken', (result as TokenResponse).accessToken);
     window.location.replace(ArcRoutes.DASHBOARD);
+  } else if (typeof result === 'number') {
+    // if we have an error code
+    window.location.replace(`${ArcRoutes.COURTESY_PAGE}?errorcode=${result}`);
   } else {
+    // otherwhise
     window.location.replace(ArcRoutes.LOGIN);
   }
 

--- a/src/routes/CourtesyPage/CourtesyPage.test.tsx
+++ b/src/routes/CourtesyPage/CourtesyPage.test.tsx
@@ -7,6 +7,11 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 const queryClient = new QueryClient();
 
 vi.mock('react-router-dom', () => ({
+  useSearchParams: () => [
+    {
+      get: () => '403'
+    }
+  ],
   useLoaderData: vi.fn(),
   Link: vi.fn()
 }));

--- a/src/routes/CourtesyPage/index.tsx
+++ b/src/routes/CourtesyPage/index.tsx
@@ -1,19 +1,29 @@
 import React from 'react';
 import { Button, Typography, Container, Box } from '@mui/material';
-import { Link } from 'react-router-dom';
+import { useSearchParams, Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 
 export const CourtesyPage = () => {
+  const { t } = useTranslation();
+  const [searchParams] = useSearchParams();
+  const errorMessage = searchParams.get('errorcode') || 'default';
+
   return (
     <Container maxWidth="sm">
       <Box textAlign="center" mt={10}>
-        <Typography variant="h4" gutterBottom>
-          Sorry, the page you're looking for does not exist.
+        <Typography variant="h4" gutterBottom data-testid="courtesyPage.title">
+          {t(`courtesyPage.${errorMessage}.title`)}
         </Typography>
-        <Typography variant="body1" paragraph>
-          Please navigate back to the homepage or try a different page.
+        <Typography variant="body1" paragraph data-testid="courtesyPage.body">
+          {t(`courtesyPage.${errorMessage}.body`)}
         </Typography>
-        <Button component={Link} to="/" variant="contained" color="primary">
-          Go to Home
+        <Button
+          component={Link}
+          to="/"
+          variant="contained"
+          color="primary"
+          data-testid="courtesyPage.cta">
+          {t(`courtesyPage.${errorMessage}.cta`)}
         </Button>
       </Box>
     </Container>

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -231,5 +231,22 @@
       "231": "Modello 231",
       "followUs": "Seguici su"
     }
+  },
+  "courtesyPage": {
+    "default": {
+      "title": "La pagina che stai cercando non esiste",
+      "body": "Puoi tornare in homepage o visitare una nuova pagina",
+      "cta": "Torna in home"
+    },
+    "401": {
+      "title": "La tua sessione è scaduta",
+      "body": "Per tornare a visualizzare il sito è necessario fare nuovamente login",
+      "cta": "Login"
+    },
+    "403": {
+      "title": "La tua utenza non è autorizzata a visionare questo sito",
+      "body": "Se credi che questo non sia corretto apri una segnalazione",
+      "cta": "Scrivi ad assistenza"
+    }
   }
 }

--- a/src/utils/loaders.test.tsx
+++ b/src/utils/loaders.test.tsx
@@ -178,21 +178,19 @@ describe('api loaders', () => {
       expect(token).toEqual(dataMock);
     });
 
-
     it('should return error code on failure', async () => {
-      const mockRequest = (url: string): Request => ({
-        url,
-      } as unknown as Request);
-      
+      const mockRequest = (url: string): Request =>
+        ({
+          url
+        }) as unknown as Request;
+
       const mockError = { response: { status: 403 } };
       vi.mocked(utils.apiClient.token.getAuthenticationToken).mockRejectedValue(mockError);
-  
+
       const request = mockRequest('https://sito.it/?code=dummyCode&state=dummyState');
       const result = await loaders.getTokenOneidentity(request);
-  
-      expect(result).toBe(403);
-    
-  });
 
+      expect(result).toBe(403);
+    });
   });
 });

--- a/src/utils/loaders.test.tsx
+++ b/src/utils/loaders.test.tsx
@@ -177,5 +177,22 @@ describe('api loaders', () => {
       );
       expect(token).toEqual(dataMock);
     });
+
+
+    it('should return error code on failure', async () => {
+      const mockRequest = (url: string): Request => ({
+        url,
+      } as unknown as Request);
+      
+      const mockError = { response: { status: 403 } };
+      vi.mocked(utils.apiClient.token.getAuthenticationToken).mockRejectedValue(mockError);
+  
+      const request = mockRequest('https://sito.it/?code=dummyCode&state=dummyState');
+      const result = await loaders.getTokenOneidentity(request);
+  
+      expect(result).toBe(403);
+    
+  });
+
   });
 });

--- a/src/utils/loaders.ts
+++ b/src/utils/loaders.ts
@@ -3,6 +3,7 @@ import { STATE } from 'store/types';
 import utils from 'utils';
 import { ZodSchema } from 'zod';
 import * as zodSchema from '../../generated/zod-schema';
+import { AxiosError } from 'axios';
 
 const parseAndLog = <T>(schema: ZodSchema, data: T, throwError: boolean = true): void | never => {
   const result = schema.safeParse(data);
@@ -92,8 +93,9 @@ export const getTokenOneidentity = async (request: Request) => {
     );
     parseAndLog(zodSchema.tokenResponseSchema, TokenResponse);
     return TokenResponse;
-  } catch {
-    return null;
+  } catch (error) {
+    const code = (error as AxiosError<{ status: number }>).response?.status;
+    return code;
   }
 };
 


### PR DESCRIPTION
This PR create an unhappy path for the login service redirecting the user to the courtesy page.

#### List of Changes
- add the Error management to the login call
- add a more reliable courtesy page

#### Motivation and Context
Try to have a specific management for unhappy cases when the user try to access

#### How Has This Been Tested?
- unit test
- manual test

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
