### PR TITLE
fix: [P4PU-643] token malformed response

### DIFF
--- a/src/routes/CourtesyPage/index.tsx
+++ b/src/routes/CourtesyPage/index.tsx
@@ -12,10 +12,12 @@ export const CourtesyPage = () => {
     <Container maxWidth="sm">
       <Box textAlign="center" mt={10}>
         <Typography variant="h4" gutterBottom data-testid="courtesyPage.title">
-          {t(`courtesyPage.${errorMessage}.title`)}
+          {t(`courtesyPage.${errorMessage}.title`, {
+            defaultValue: t('courtesyPage.default.title')
+          })}
         </Typography>
         <Typography variant="body1" paragraph data-testid="courtesyPage.body">
-          {t(`courtesyPage.${errorMessage}.body`)}
+          {t(`courtesyPage.${errorMessage}.body`, { defaultValue: t('courtesyPage.default.body') })}
         </Typography>
         <Button
           component={Link}
@@ -23,7 +25,7 @@ export const CourtesyPage = () => {
           variant="contained"
           color="primary"
           data-testid="courtesyPage.cta">
-          {t(`courtesyPage.${errorMessage}.cta`)}
+          {t(`courtesyPage.${errorMessage}.cta`, { defaultValue: t('courtesyPage.default.cta') })}
         </Button>
       </Box>
     </Container>

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -252,6 +252,11 @@
       "title": "La tua utenza non è autorizzata a visionare questo sito",
       "body": "Se credi che questo non sia corretto apri una segnalazione",
       "cta": "Scrivi ad assistenza"
+    },
+    "408": {
+      "title": "Il sistema ha impiegato troppo tempo a rispondere",
+      "body": "Prova ad effettuare nuovamente il login",
+      "cta": "Login"
     }
   }
 }

--- a/src/utils/interceptors.ts
+++ b/src/utils/interceptors.ts
@@ -10,7 +10,6 @@ export const setupInterceptors = (client: Client, navigate: NavigateFunction) =>
     (request: InternalAxiosRequestConfig) => {
       const tokenHeaderExcludePaths: string[] = utils.config.tokenHeaderExcludePaths;
       const routeUrl = request.url || '';
-      request.timeout = 6000;
       const accessToken = window.localStorage.getItem('accessToken');
       if (accessToken && !tokenHeaderExcludePaths.includes(routeUrl)) {
         request.headers['Authorization'] = `Bearer ${accessToken}`;

--- a/src/utils/interceptors.ts
+++ b/src/utils/interceptors.ts
@@ -3,19 +3,21 @@ import utils from 'utils';
 import { Client } from 'models/Client';
 import { sessionClear } from './session';
 import { ArcRoutes } from 'routes/routes';
+import { AxiosError, InternalAxiosRequestConfig } from 'axios';
 
 export const setupInterceptors = (client: Client, navigate: NavigateFunction) => {
   client.instance.interceptors.request.use(
-    (request) => {
+    (request: InternalAxiosRequestConfig) => {
       const tokenHeaderExcludePaths: string[] = utils.config.tokenHeaderExcludePaths;
       const routeUrl = request.url || '';
+      request.timeout = 6000;
       const accessToken = window.localStorage.getItem('accessToken');
       if (accessToken && !tokenHeaderExcludePaths.includes(routeUrl)) {
         request.headers['Authorization'] = `Bearer ${accessToken}`;
       }
       return request;
     },
-    (error) => {
+    (error: Promise<AxiosError>) => {
       return Promise.reject(error);
     }
   );

--- a/src/utils/loaders.ts
+++ b/src/utils/loaders.ts
@@ -107,7 +107,7 @@ export const getTokenOneidentity = async (request: Request) => {
     parseAndLog(zodSchema.tokenResponseSchema, TokenResponse);
     return TokenResponse;
   } catch (error) {
-    const code = (error as AxiosError<{ status: number }>).response?.status;
+    const code = (error as AxiosError<{ status: number }>).response?.status || 408;
     return code;
   }
 };


### PR DESCRIPTION
This PR fixes the un managed "empty" response from OI endpoint.

#### List of Changes
- add a default value `408` to manage an empty response
- edit the translation file to alert the user in Courtesypage

#### Motivation and Context
The endpoint of OI can drop the connection sometime.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
