### PR TITLE
feat: [P4PU-599] Notices list pagination

### DIFF
--- a/src/components/Transactions/Transactions.tsx
+++ b/src/components/Transactions/Transactions.tsx
@@ -9,6 +9,8 @@ import { useTranslation } from 'react-i18next';
 
 export interface TransactionsProps {
   rows?: TransactionProps[];
+  dateOrder?: 'ASC' | 'DESC';
+  onDateOrderClick?: () => void;
 }
 
 const Transactions = (props: TransactionsProps) => {
@@ -23,8 +25,8 @@ const Transactions = (props: TransactionsProps) => {
             <TableCell sx={{ paddingTop: 0.75, paddingBottom: 1 }} width="60%">
               {t('app.transactions.payee')}
             </TableCell>
-            <TableCell sx={{ paddingTop: 0.75, paddingBottom: 1 }}>
-              {t('app.transactions.date')}
+            <TableCell sx={{ paddingTop: 0.75, paddingBottom: 1 }} onClick={props.onDateOrderClick}>
+              {t('app.transactions.date')} {props.dateOrder}
             </TableCell>
             <TableCell sx={{ paddingTop: 0.75, paddingBottom: 1 }}>
               {t('app.transactions.amount')}

--- a/src/components/Transactions/Transactions.tsx
+++ b/src/components/Transactions/Transactions.tsx
@@ -13,9 +13,11 @@ export interface TransactionsProps {
   rows?: TransactionProps[];
   dateOrdering?: 'ASC' | 'DESC';
   onDateOrderClick?: () => void;
+  hideDateOrdering?: boolean;
 }
 
 const Transactions = (props: TransactionsProps) => {
+  const { hideDateOrdering = false } = props;
   const { t } = useTranslation();
   const mdUp = useMediaQuery((theme: Theme) => theme.breakpoints.up('md'));
 
@@ -30,11 +32,13 @@ const Transactions = (props: TransactionsProps) => {
             <TableCell sx={{ paddingTop: 0.75, paddingBottom: 1 }} onClick={props.onDateOrderClick}>
               <Stack direction="row" sx={{ cursor: 'pointer' }}>
                 <span>{t('app.transactions.date')}</span>
-                {props.dateOrdering === 'DESC' ? (
-                  <ArrowDownwardIcon sx={{ width: '18px' }} />
-                ) : (
-                  <ArrowUpwardIcon sx={{ width: '18px' }} />
-                )}
+                {!hideDateOrdering ? (
+                  props.dateOrdering === 'DESC' ? (
+                    <ArrowDownwardIcon sx={{ width: '18px' }} />
+                  ) : (
+                    <ArrowUpwardIcon sx={{ width: '18px' }} />
+                  )
+                ) : null}
               </Stack>
             </TableCell>
             <TableCell sx={{ paddingTop: 0.75, paddingBottom: 1 }}>

--- a/src/components/Transactions/Transactions.tsx
+++ b/src/components/Transactions/Transactions.tsx
@@ -4,12 +4,14 @@ import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableContainer from '@mui/material/TableContainer';
 import Transaction from './Transaction';
-import { TableHead, TableRow, TableCell, useMediaQuery, Theme } from '@mui/material';
+import { TableHead, TableRow, TableCell, useMediaQuery, Theme, Stack } from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 
 export interface TransactionsProps {
   rows?: TransactionProps[];
-  dateOrder?: 'ASC' | 'DESC';
+  dateOrdering?: 'ASC' | 'DESC';
   onDateOrderClick?: () => void;
 }
 
@@ -26,7 +28,14 @@ const Transactions = (props: TransactionsProps) => {
               {t('app.transactions.payee')}
             </TableCell>
             <TableCell sx={{ paddingTop: 0.75, paddingBottom: 1 }} onClick={props.onDateOrderClick}>
-              {t('app.transactions.date')} {props.dateOrder}
+              <Stack direction="row" sx={{ cursor: 'pointer' }}>
+                <span>{t('app.transactions.date')}</span>
+                {props.dateOrdering === 'DESC' ? (
+                  <ArrowDownwardIcon sx={{ width: '18px' }} />
+                ) : (
+                  <ArrowUpwardIcon sx={{ width: '18px' }} />
+                )}
+              </Stack>
             </TableCell>
             <TableCell sx={{ paddingTop: 0.75, paddingBottom: 1 }}>
               {t('app.transactions.amount')}

--- a/src/hooks/useNormalizedNoticesList.test.tsx
+++ b/src/hooks/useNormalizedNoticesList.test.tsx
@@ -4,7 +4,7 @@ import { useNormalizedNoticesList } from './useNormalizedNoticesList';
 import { Mock } from 'vitest';
 import converters from 'utils/converters';
 import loaders from 'utils/loaders';
-import { NoticesListDTO } from '../../generated/apiClient';
+import { NoticeDTO } from '../../generated/apiClient';
 import { UseQueryResult } from '@tanstack/react-query';
 import { i18nTestSetup } from '__tests__/i18nTestSetup';
 
@@ -26,25 +26,25 @@ describe('useNormalizedNoticesList', () => {
   });
 
   it('returns all notices and processes data correctly', async () => {
-    const mockNoticesList = {
-      notices: [
-        { id: '1', paidByMe: true, registeredToMe: false },
-        { id: '2', paidByMe: false, registeredToMe: true },
-        { id: '3', paidByMe: true, registeredToMe: true }
-      ]
-    };
+    const mockNoticesList = [
+      { id: '1', paidByMe: true, registeredToMe: false },
+      { id: '2', paidByMe: false, registeredToMe: true },
+      { id: '3', paidByMe: true, registeredToMe: true }
+    ];
 
     const preparedData = [{ id: '1' }, { id: '2' }, { id: '3' }];
 
     vi.mocked(loaders.getNoticesList).mockReturnValue({
-      data: mockNoticesList,
+      data: { notices: mockNoticesList, continuationToken: '' },
       isError: false
-    } as unknown as UseQueryResult<NoticesListDTO, Error>);
+    } as unknown as UseQueryResult<{ notices: NoticeDTO[]; continuationToken: string }, Error>);
 
     const mockPrepareRowsData = vi.fn().mockReturnValue(preparedData);
     converters.prepareRowsData = mockPrepareRowsData;
 
-    const { result } = renderHook(() => useNormalizedNoticesList());
+    const { result } = renderHook(() =>
+      useNormalizedNoticesList({ continuationToken: '', ordering: 'DESC' })
+    );
 
     await waitFor(() => {
       expect(result.current.all).toEqual(preparedData);
@@ -54,7 +54,7 @@ describe('useNormalizedNoticesList', () => {
 
       expect(mockPrepareRowsData).toBeCalledTimes(1);
       expect(mockPrepareRowsData).toHaveBeenCalledWith({
-        notices: mockNoticesList.notices,
+        notices: mockNoticesList,
         status: { label: 'app.transactions.paid' },
         payee: { multi: 'app.transactions.multiEntities' }
       });
@@ -62,25 +62,25 @@ describe('useNormalizedNoticesList', () => {
   });
 
   it('returns payedByMe notices and processes data correctly', async () => {
-    const mockNoticesList = {
-      notices: [
-        { id: '1', paidByMe: true, registeredToMe: false },
-        { id: '2', paidByMe: false, registeredToMe: true },
-        { id: '3', paidByMe: true, registeredToMe: true }
-      ]
-    };
+    const mockNoticesList = [
+      { id: '1', paidByMe: true, registeredToMe: false },
+      { id: '2', paidByMe: false, registeredToMe: true },
+      { id: '3', paidByMe: true, registeredToMe: true }
+    ];
 
     const preparedData = [{ id: '1' }, { id: '3' }];
 
     vi.mocked(loaders.getNoticesList).mockReturnValue({
-      data: mockNoticesList,
+      data: { notices: mockNoticesList, continuationToken: '' },
       isError: false
-    } as unknown as UseQueryResult<NoticesListDTO, Error>);
+    } as unknown as UseQueryResult<{ notices: NoticeDTO[]; continuationToken: string }, Error>);
 
     const mockPrepareRowsData = vi.fn().mockReturnValue(preparedData);
     converters.prepareRowsData = mockPrepareRowsData;
 
-    const { result } = renderHook(() => useNormalizedNoticesList({ paidByMe: true }));
+    const { result } = renderHook(() =>
+      useNormalizedNoticesList({ paidByMe: true, continuationToken: '', ordering: 'DESC' })
+    );
 
     await waitFor(() => {
       expect(result.current.all).toEqual([]);
@@ -90,7 +90,7 @@ describe('useNormalizedNoticesList', () => {
 
       expect(mockPrepareRowsData).toBeCalledTimes(1);
       expect(mockPrepareRowsData).toHaveBeenCalledWith({
-        notices: mockNoticesList.notices,
+        notices: mockNoticesList,
         status: { label: 'app.transactions.paid' },
         payee: { multi: 'app.transactions.multiEntities' }
       });
@@ -98,24 +98,24 @@ describe('useNormalizedNoticesList', () => {
   });
 
   it('returns registeredToMe notices and processes data correctly', async () => {
-    const mockNoticesList = {
-      notices: [
-        { id: '1', paidByMe: true, registeredToMe: false },
-        { id: '2', paidByMe: false, registeredToMe: true },
-        { id: '3', paidByMe: true, registeredToMe: true }
-      ]
-    };
+    const mockNoticesList = [
+      { id: '1', paidByMe: true, registeredToMe: false },
+      { id: '2', paidByMe: false, registeredToMe: true },
+      { id: '3', paidByMe: true, registeredToMe: true }
+    ];
 
     const preparedData = [{ id: '2' }, { id: '3' }];
     vi.mocked(loaders.getNoticesList).mockReturnValue({
-      data: mockNoticesList,
+      data: { notices: mockNoticesList, continuationToken: '' },
       isError: false
-    } as unknown as UseQueryResult<NoticesListDTO, Error>);
+    } as unknown as UseQueryResult<{ notices: NoticeDTO[]; continuationToken: string }, Error>);
 
     const mockPrepareRowsData = vi.fn().mockReturnValue(preparedData);
     converters.prepareRowsData = mockPrepareRowsData;
 
-    const { result } = renderHook(() => useNormalizedNoticesList({ registeredToMe: true }));
+    const { result } = renderHook(() =>
+      useNormalizedNoticesList({ registeredToMe: true, continuationToken: '', ordering: 'DESC' })
+    );
 
     await waitFor(() => {
       expect(result.current.all).toEqual([]);
@@ -125,7 +125,7 @@ describe('useNormalizedNoticesList', () => {
 
       expect(mockPrepareRowsData).toBeCalledTimes(1);
       expect(mockPrepareRowsData).toHaveBeenCalledWith({
-        notices: mockNoticesList.notices,
+        notices: mockNoticesList,
         status: { label: 'app.transactions.paid' },
         payee: { multi: 'app.transactions.multiEntities' }
       });
@@ -134,11 +134,13 @@ describe('useNormalizedNoticesList', () => {
 
   it('handles error state correctly', async () => {
     vi.mocked(loaders.getNoticesList).mockReturnValue({
-      data: null as unknown as NoticesListDTO,
+      data: null,
       isError: true
-    } as unknown as UseQueryResult<NoticesListDTO, Error>);
+    } as unknown as UseQueryResult<{ notices: NoticeDTO[]; continuationToken: string }, Error>);
 
-    const { result } = renderHook(() => useNormalizedNoticesList());
+    const { result } = renderHook(() =>
+      useNormalizedNoticesList({ continuationToken: '', ordering: 'DESC' })
+    );
 
     await waitFor(() => {
       expect(result.current.all).toEqual([]);

--- a/src/hooks/useNormalizedNoticesList.tsx
+++ b/src/hooks/useNormalizedNoticesList.tsx
@@ -4,14 +4,19 @@ import { useTranslation } from 'react-i18next';
 interface NormalizedNoticesListParams {
   paidByMe?: boolean;
   registeredToMe?: boolean;
-  continuationToken?: string;
-  ordering?: 'ASC' | 'DESC';
+  continuationToken: string;
+  ordering: 'ASC' | 'DESC';
 }
 
-export const useNormalizedNoticesList = (params?: NormalizedNoticesListParams) => {
+export const useNormalizedNoticesList = (params: NormalizedNoticesListParams) => {
   const { t } = useTranslation();
   const queryResult = utils.loaders.getNoticesList(
-    { ...params, size: 10 },
+    {
+      size: 10,
+      ordering: params.ordering,
+      paidByMe: params.paidByMe,
+      registeredToMe: params.registeredToMe
+    },
     params?.continuationToken
   );
   const { data } = queryResult;
@@ -19,16 +24,16 @@ export const useNormalizedNoticesList = (params?: NormalizedNoticesListParams) =
   const getNoticesList = () =>
     data
       ? utils.converters.prepareRowsData({
-          notices: data.noticesList.notices,
+          notices: data.notices,
           status: { label: t('app.transactions.paid') },
           payee: { multi: t('app.transactions.multiEntities') }
         })
       : [];
 
   const noticesList = {
-    all: !params?.paidByMe && !params?.registeredToMe ? getNoticesList() : [],
-    paidByMe: params?.paidByMe ? getNoticesList() : [],
-    registeredToMe: params?.registeredToMe ? getNoticesList() : [],
+    all: !params.paidByMe && !params.registeredToMe ? getNoticesList() : [],
+    paidByMe: params.paidByMe ? getNoticesList() : [],
+    registeredToMe: params.registeredToMe ? getNoticesList() : [],
     queryResult,
     token: data?.continuationToken
   };

--- a/src/hooks/useNormalizedNoticesList.tsx
+++ b/src/hooks/useNormalizedNoticesList.tsx
@@ -4,18 +4,21 @@ import { useTranslation } from 'react-i18next';
 interface NormalizedNoticesListParams {
   paidByMe?: boolean;
   registeredToMe?: boolean;
+  continuationToken?: string;
 }
 
 export const useNormalizedNoticesList = (params?: NormalizedNoticesListParams) => {
   const { t } = useTranslation();
-  // size = 100 to be modified when the pagination will be introduced
-  const queryResult = utils.loaders.getNoticesList({ ...params, size: 100 });
+  const queryResult = utils.loaders.getNoticesList(
+    { ...params, size: 10 },
+    params?.continuationToken
+  );
   const { data } = queryResult;
 
   const getNoticesList = () =>
     data
       ? utils.converters.prepareRowsData({
-          notices: data.notices,
+          notices: data.noticesList.notices,
           status: { label: t('app.transactions.paid') },
           payee: { multi: t('app.transactions.multiEntities') }
         })
@@ -25,7 +28,8 @@ export const useNormalizedNoticesList = (params?: NormalizedNoticesListParams) =
     all: !params?.paidByMe && !params?.registeredToMe ? getNoticesList() : [],
     paidByMe: params?.paidByMe ? getNoticesList() : [],
     registeredToMe: params?.registeredToMe ? getNoticesList() : [],
-    queryResult
+    queryResult,
+    token: data?.continuationToken
   };
 
   return noticesList;

--- a/src/hooks/useNormalizedNoticesList.tsx
+++ b/src/hooks/useNormalizedNoticesList.tsx
@@ -5,6 +5,7 @@ interface NormalizedNoticesListParams {
   paidByMe?: boolean;
   registeredToMe?: boolean;
   continuationToken?: string;
+  ordering?: 'ASC' | 'DESC';
 }
 
 export const useNormalizedNoticesList = (params?: NormalizedNoticesListParams) => {

--- a/src/routes/Dashboard/index.tsx
+++ b/src/routes/Dashboard/index.tsx
@@ -15,7 +15,13 @@ import { useUserInfo } from 'hooks/useUserInfo';
 
 const Dashboard = () => {
   const { t } = useTranslation();
-  const { data, isError, refetch } = utils.loaders.getNoticesList({ size: 5 });
+  const { data, isError, refetch } = utils.loaders.getNoticesList(
+    {
+      size: 5,
+      ordering: 'DESC'
+    },
+    ''
+  );
   const theme = useTheme();
   const optIn = utils.storage.pullPaymentsOptIn.get();
   const { userInfo } = useUserInfo();
@@ -23,7 +29,7 @@ const Dashboard = () => {
   const rows =
     data &&
     utils.converters.prepareRowsData({
-      notices: data.noticesList.notices,
+      notices: data.notices,
       status: { label: t('app.transactions.paid') },
       payee: { multi: t('app.transactions.multiEntities') }
     });

--- a/src/routes/Dashboard/index.tsx
+++ b/src/routes/Dashboard/index.tsx
@@ -37,7 +37,7 @@ const Dashboard = () => {
   const Content = () => {
     if (isError || !rows) return <Retry action={refetch} />;
     if (rows.length === 0) return <Empty />;
-    return <TransactionsList rows={rows} />;
+    return <TransactionsList rows={rows} hideDateOrdering />;
   };
 
   return (

--- a/src/routes/Dashboard/index.tsx
+++ b/src/routes/Dashboard/index.tsx
@@ -23,7 +23,7 @@ const Dashboard = () => {
   const rows =
     data &&
     utils.converters.prepareRowsData({
-      notices: data.notices,
+      notices: data.noticesList.notices,
       status: { label: t('app.transactions.paid') },
       payee: { multi: t('app.transactions.multiEntities') }
     });

--- a/src/routes/NoticesList/NoticesList.test.tsx
+++ b/src/routes/NoticesList/NoticesList.test.tsx
@@ -145,11 +145,28 @@ describe('NoticesListRoute', () => {
     });
 
     fireEvent.click(screen.getByText('app.transactions.paidByMe'));
-
     await waitFor(() => {
       expect(loaders.getNoticesList).toHaveBeenCalled();
       expect(loaders.getNoticesList).toBeCalledWith(
         { registeredToMe: undefined, paidByMe: true, size: 10, ordering: 'DESC' },
+        ''
+      );
+    });
+
+    fireEvent.click(screen.getByText('app.transactions.ownedByMe'));
+    await waitFor(() => {
+      expect(loaders.getNoticesList).toHaveBeenCalled();
+      expect(loaders.getNoticesList).toBeCalledWith(
+        { registeredToMe: true, paidByMe: undefined, size: 10, ordering: 'DESC' },
+        ''
+      );
+    });
+
+    fireEvent.click(screen.getByText('app.transactions.all'));
+    await waitFor(() => {
+      expect(loaders.getNoticesList).toHaveBeenCalled();
+      expect(loaders.getNoticesList).toBeCalledWith(
+        { registeredToMe: undefined, paidByMe: undefined, size: 10, ordering: 'DESC' },
         ''
       );
     });

--- a/src/routes/NoticesList/NoticesList.test.tsx
+++ b/src/routes/NoticesList/NoticesList.test.tsx
@@ -52,11 +52,13 @@ describe('NoticesListRoute', () => {
         { id: '2', paidByMe: false, registeredToMe: true }
       ]
     };
-
     (loaders.getNoticesList as Mock).mockReturnValue({
-      data: mockNoticesList,
+      data: {
+        notices: mockNoticesList.notices,
+        continuationToken: ''
+      },
       isError: false,
-      refetch: vi.fn()
+      refetch: () => ({ data: { continuationToken: '' } })
     });
 
     render(
@@ -74,7 +76,7 @@ describe('NoticesListRoute', () => {
     (loaders.getNoticesList as Mock).mockReturnValue({
       data: null,
       isError: true,
-      refetch: vi.fn()
+      refetch: () => ({ data: null })
     });
 
     render(
@@ -91,10 +93,11 @@ describe('NoticesListRoute', () => {
   it('gives a proper feedback when no data is returned', async () => {
     (loaders.getNoticesList as Mock).mockReturnValue({
       data: {
-        notices: []
+        notices: [],
+        continuationToken: ''
       },
       isError: false,
-      refetch: vi.fn()
+      refetch: () => ({ data: { notices: [], continuationToken: '' } })
     });
 
     render(
@@ -115,10 +118,11 @@ describe('NoticesListRoute', () => {
     };
     (loaders.getNoticesList as Mock).mockReturnValue({
       data: {
-        notices: mockNoticesList
+        notices: mockNoticesList.notices,
+        continuationToken: ''
       },
       isError: false,
-      refetch: vi.fn()
+      refetch: () => ({ data: { notices: mockNoticesList.notices, continuationToken: '' } })
     });
 
     render(
@@ -129,28 +133,50 @@ describe('NoticesListRoute', () => {
 
     await waitFor(() => {
       expect(loaders.getNoticesList).toHaveBeenCalled();
-      expect(loaders.getNoticesList).toBeCalledWith({ size: 100 });
+      expect(loaders.getNoticesList).toBeCalledWith(
+        {
+          size: 10,
+          paidByMe: undefined,
+          registeredToMe: undefined,
+          ordering: 'DESC'
+        },
+        ''
+      );
     });
 
     fireEvent.click(screen.getByText('app.transactions.paidByMe'));
 
     await waitFor(() => {
       expect(loaders.getNoticesList).toHaveBeenCalled();
-      expect(loaders.getNoticesList).toBeCalledWith({ paidByMe: true, size: 100 });
+      expect(loaders.getNoticesList).toBeCalledWith(
+        { registeredToMe: undefined, paidByMe: true, size: 10, ordering: 'DESC' },
+        ''
+      );
     });
 
     fireEvent.click(screen.getByText('app.transactions.ownedByMe'));
 
     await waitFor(() => {
       expect(loaders.getNoticesList).toHaveBeenCalled();
-      expect(loaders.getNoticesList).toBeCalledWith({ registeredToMe: true, size: 100 });
+      expect(loaders.getNoticesList).toBeCalledWith(
+        { paidByMe: undefined, registeredToMe: true, size: 10, ordering: 'DESC' },
+        ''
+      );
     });
 
     fireEvent.click(screen.getByText('app.transactions.all'));
 
     await waitFor(() => {
       expect(loaders.getNoticesList).toHaveBeenCalled();
-      expect(loaders.getNoticesList).toBeCalledWith({ size: 100 });
+      expect(loaders.getNoticesList).toBeCalledWith(
+        {
+          size: 10,
+          paidByMe: undefined,
+          registeredToMe: undefined,
+          ordering: 'DESC'
+        },
+        ''
+      );
     });
   });
 });

--- a/src/routes/NoticesList/index.tsx
+++ b/src/routes/NoticesList/index.tsx
@@ -8,6 +8,7 @@ import { useNormalizedNoticesList } from 'hooks/useNormalizedNoticesList';
 import Empty from 'components/Transactions/Empty';
 import Retry from 'components/Transactions/Retry';
 import { TransactionListSkeleton } from 'components/Skeleton';
+import { PaginationItem } from '@mui/material';
 
 enum NoticesTabs {
   all,
@@ -20,8 +21,8 @@ export default function NoticesListPage() {
     paidByMe?: boolean;
     registeredToMe?: boolean;
     /** continuation token, used to paginate the elements */
-    token?: string;
-  }>({});
+    continuationToken?: string;
+  }>();
 
   const [activeTab, setActiveTab] = React.useState(NoticesTabs.all);
   const [currentPage, setCurrentPages] = React.useState(0);
@@ -52,7 +53,7 @@ export default function NoticesListPage() {
   const goToPage = (direction: number) => {
     const pageIndex = currentPage + direction;
     setCurrentPages(pageIndex);
-    setNoticeQueryParams({ ...noticeQueryParams, token: pages[pageIndex] });
+    setNoticeQueryParams({ ...noticeQueryParams, continuationToken: pages[pageIndex] });
   };
 
   // pages
@@ -103,15 +104,26 @@ export default function NoticesListPage() {
             }
           ]}
         />
-        <button disabled={currentPage === 0} onClick={() => goToPage(-1)}>
-          indietro
-        </button>
-        <button disabled={pages[currentPage + 1] === undefined} onClick={() => goToPage(+1)}>
-          avanti
-        </button>
       </>
     );
   };
+
+  const Pagination = () => (
+    <Stack direction={'row'} justifyContent={'end'} pt={2}>
+      <PaginationItem
+        disabled={currentPage === 0}
+        onClick={() => goToPage(-1)}
+        size="medium"
+        type="previous"
+      />
+      <PaginationItem
+        disabled={pages[currentPage + 1] === undefined}
+        onClick={() => goToPage(+1)}
+        size="medium"
+        type="next"
+      />
+    </Stack>
+  );
 
   return (
     <>
@@ -124,14 +136,17 @@ export default function NoticesListPage() {
           if (error || !data || !data.noticesList.notices) return <Retry action={refetch} />;
           if (data.noticesList.notices?.length === 0) return <Empty />;
           return (
-            <MainContent
-              all={noticesList.all}
-              paidByMe={noticesList.paidByMe}
-              registeredToMe={noticesList.registeredToMe}
-            />
+            <>
+              <MainContent
+                all={noticesList.all}
+                paidByMe={noticesList.paidByMe}
+                registeredToMe={noticesList.registeredToMe}
+              />
+            </>
           );
         })()}
       </QueryLoader>
+      {pages.length > 1 && <Pagination />}
     </>
   );
 }

--- a/src/routes/NoticesList/index.tsx
+++ b/src/routes/NoticesList/index.tsx
@@ -56,6 +56,12 @@ export default function NoticesListPage() {
     setNoticeQueryParams({ ...noticeQueryParams, continuationToken: pages[pageIndex] });
   };
 
+  const resetPagination = () => {
+    setCurrentPages(0);
+    setPages(['']);
+    setNoticeQueryParams({ ...noticeQueryParams, continuationToken: '' });
+  };
+
   // pages
   React.useEffect(() => {
     (async () => {
@@ -71,6 +77,7 @@ export default function NoticesListPage() {
 
   // activetab
   React.useEffect(() => {
+    resetPagination();
     refetch();
   }, [activeTab]);
 

--- a/src/routes/NoticesList/index.tsx
+++ b/src/routes/NoticesList/index.tsx
@@ -31,17 +31,6 @@ export default function NoticesListPage() {
   const [dateOrdering, setDateOrdering] = React.useState<'ASC' | 'DESC'>('DESC');
   const [pages, setPages] = React.useState(['']);
 
-  // console.log(
-  //   'activeTab',
-  //   activeTab,
-  //   'currentPage',
-  //   currentPage,
-  //   'dateOrder',
-  //   dateOrder,
-  //   'pages',
-  //   pages
-  // );
-
   const { t } = useTranslation();
 
   const noticesList = useNormalizedNoticesList(noticeQueryParams);

--- a/src/routes/NoticesList/index.tsx
+++ b/src/routes/NoticesList/index.tsx
@@ -167,12 +167,14 @@ export default function NoticesListPage() {
         onClick={() => goToPage(-1)}
         size="medium"
         type="previous"
+        data-testid="notices-pagination-prev"
       />
       <PaginationItem
         disabled={pages[currentPage + 1] === undefined}
         onClick={() => goToPage(+1)}
         size="medium"
         type="next"
+        data-testid="notices-pagination-next"
       />
     </Stack>
   );

--- a/src/routes/NoticesList/index.tsx
+++ b/src/routes/NoticesList/index.tsx
@@ -32,17 +32,6 @@ export default function NoticesListPage() {
 
   const { t } = useTranslation();
 
-  console.log(
-    'activeTab',
-    activeTab,
-    'currentPage',
-    currentPage,
-    'dateOrding',
-    noticeQueryParams.ordering,
-    'pages',
-    pages
-  );
-
   const noticesList = useNormalizedNoticesList(noticeQueryParams);
 
   const {

--- a/src/routes/NoticesList/index.tsx
+++ b/src/routes/NoticesList/index.tsx
@@ -97,7 +97,7 @@ export default function NoticesListPage() {
       if (!continuationToken) return;
       // is a new token? if not, no need to update the token pages array
       const isNewToken = !pages.find((oldToken) => oldToken === continuationToken);
-      if (isNewToken) setPages([...pages, continuationToken]);
+      if (isNewToken) setPages((prevPages) => [...prevPages, continuationToken]);
     })();
   }, [currentPage, activeTab, noticeQueryParams.ordering]);
 

--- a/src/routes/NoticesList/index.tsx
+++ b/src/routes/NoticesList/index.tsx
@@ -22,14 +22,25 @@ export default function NoticesListPage() {
     registeredToMe?: boolean;
     /** continuation token, used to paginate the elements */
     continuationToken?: string;
+    /** date order, the only one avaiable. default DESC */
     ordering?: 'ASC' | 'DESC';
-  }>();
+  }>({ continuationToken: '', ordering: 'DESC' });
 
   const [activeTab, setActiveTab] = React.useState(NoticesTabs.all);
   const [currentPage, setCurrentPages] = React.useState(0);
-  const [dateOrder, setDateOrder] = React.useState<'ASC' | 'DESC'>('DESC');
-
+  const [dateOrdering, setDateOrdering] = React.useState<'ASC' | 'DESC'>('DESC');
   const [pages, setPages] = React.useState(['']);
+
+  // console.log(
+  //   'activeTab',
+  //   activeTab,
+  //   'currentPage',
+  //   currentPage,
+  //   'dateOrder',
+  //   dateOrder,
+  //   'pages',
+  //   pages
+  // );
 
   const { t } = useTranslation();
 
@@ -42,18 +53,26 @@ export default function NoticesListPage() {
   const resetPagination = () => {
     setCurrentPages(0);
     setPages(['']);
-    setNoticeQueryParams({ ...noticeQueryParams, continuationToken: '' });
   };
 
-  const onDateOrderChange = () => {
+  const resetDateOrdering = () => {
+    setDateOrdering('DESC');
+  };
+
+  const toggleDateOrder = () => {
     resetPagination();
-    const newDateOrder = dateOrder === 'DESC' ? 'ASC' : 'DESC';
-    setDateOrder(newDateOrder);
-    setNoticeQueryParams({ ...noticeQueryParams, ordering: newDateOrder });
+    const newDateOrdering = dateOrdering === 'DESC' ? 'ASC' : 'DESC';
+    setDateOrdering(newDateOrdering);
+    setNoticeQueryParams({
+      ...noticeQueryParams,
+      ordering: newDateOrdering,
+      continuationToken: ''
+    });
   };
 
   const onTabChange = (activeTab: NoticesTabs) => {
     resetPagination();
+    resetDateOrdering();
     setActiveTab(activeTab);
     switch (activeTab) {
       case NoticesTabs.all:
@@ -83,7 +102,7 @@ export default function NoticesListPage() {
       const isNewToken = !pages.find((oldToken) => oldToken === continuationToken);
       if (isNewToken) setPages([...pages, continuationToken]);
     })();
-  }, [currentPage, activeTab, dateOrder]);
+  }, [currentPage, activeTab, dateOrdering]);
 
   const MainContent = ({
     all,
@@ -106,8 +125,8 @@ export default function NoticesListPage() {
               content: (
                 <TransactionsList
                   rows={all}
-                  dateOrder={dateOrder}
-                  onDateOrderClick={onDateOrderChange}
+                  dateOrdering={dateOrdering}
+                  onDateOrderClick={toggleDateOrder}
                 />
               )
             },
@@ -116,8 +135,8 @@ export default function NoticesListPage() {
               content: (
                 <TransactionsList
                   rows={paidByMe}
-                  dateOrder={dateOrder}
-                  onDateOrderClick={onDateOrderChange}
+                  dateOrdering={dateOrdering}
+                  onDateOrderClick={toggleDateOrder}
                 />
               )
             },
@@ -126,8 +145,8 @@ export default function NoticesListPage() {
               content: (
                 <TransactionsList
                   rows={registeredToMe}
-                  dateOrder={dateOrder}
-                  onDateOrderClick={onDateOrderChange}
+                  dateOrdering={dateOrdering}
+                  onDateOrderClick={toggleDateOrder}
                 />
               )
             }

--- a/src/routes/NoticesList/index.tsx
+++ b/src/routes/NoticesList/index.tsx
@@ -22,10 +22,13 @@ export default function NoticesListPage() {
     registeredToMe?: boolean;
     /** continuation token, used to paginate the elements */
     continuationToken?: string;
+    ordering?: 'ASC' | 'DESC';
   }>();
 
   const [activeTab, setActiveTab] = React.useState(NoticesTabs.all);
   const [currentPage, setCurrentPages] = React.useState(0);
+  const [dateOrder, setDateOrder] = React.useState<'ASC' | 'DESC'>('DESC');
+
   const [pages, setPages] = React.useState(['']);
 
   const { t } = useTranslation();
@@ -36,7 +39,21 @@ export default function NoticesListPage() {
     queryResult: { data, error, refetch }
   } = noticesList;
 
+  const resetPagination = () => {
+    setCurrentPages(0);
+    setPages(['']);
+    setNoticeQueryParams({ ...noticeQueryParams, continuationToken: '' });
+  };
+
+  const onDateOrderChange = () => {
+    resetPagination();
+    const newDateOrder = dateOrder === 'DESC' ? 'ASC' : 'DESC';
+    setDateOrder(newDateOrder);
+    setNoticeQueryParams({ ...noticeQueryParams, ordering: newDateOrder });
+  };
+
   const onTabChange = (activeTab: NoticesTabs) => {
+    resetPagination();
     setActiveTab(activeTab);
     switch (activeTab) {
       case NoticesTabs.all:
@@ -56,13 +73,6 @@ export default function NoticesListPage() {
     setNoticeQueryParams({ ...noticeQueryParams, continuationToken: pages[pageIndex] });
   };
 
-  const resetPagination = () => {
-    setCurrentPages(0);
-    setPages(['']);
-    setNoticeQueryParams({ ...noticeQueryParams, continuationToken: '' });
-  };
-
-  // pages
   React.useEffect(() => {
     (async () => {
       const response = await refetch();
@@ -73,13 +83,7 @@ export default function NoticesListPage() {
       const isNewToken = !pages.find((oldToken) => oldToken === continuationToken);
       if (isNewToken) setPages([...pages, continuationToken]);
     })();
-  }, [currentPage]);
-
-  // activetab
-  React.useEffect(() => {
-    resetPagination();
-    refetch();
-  }, [activeTab]);
+  }, [currentPage, activeTab, dateOrder]);
 
   const MainContent = ({
     all,
@@ -99,15 +103,33 @@ export default function NoticesListPage() {
           tabs={[
             {
               title: t('app.transactions.all'),
-              content: <TransactionsList rows={all} />
+              content: (
+                <TransactionsList
+                  rows={all}
+                  dateOrder={dateOrder}
+                  onDateOrderClick={onDateOrderChange}
+                />
+              )
             },
             {
               title: t('app.transactions.paidByMe'),
-              content: <TransactionsList rows={paidByMe} />
+              content: (
+                <TransactionsList
+                  rows={paidByMe}
+                  dateOrder={dateOrder}
+                  onDateOrderClick={onDateOrderChange}
+                />
+              )
             },
             {
               title: t('app.transactions.ownedByMe'),
-              content: <TransactionsList rows={registeredToMe} />
+              content: (
+                <TransactionsList
+                  rows={registeredToMe}
+                  dateOrder={dateOrder}
+                  onDateOrderClick={onDateOrderChange}
+                />
+              )
             }
           ]}
         />

--- a/src/routes/NoticesList/index.tsx
+++ b/src/routes/NoticesList/index.tsx
@@ -21,9 +21,9 @@ export default function NoticesListPage() {
     paidByMe?: boolean;
     registeredToMe?: boolean;
     /** continuation token, used to paginate the elements */
-    continuationToken?: string;
+    continuationToken: string;
     /** date order, the only one avaiable. default DESC */
-    ordering?: 'ASC' | 'DESC';
+    ordering: 'ASC' | 'DESC';
   }>({ continuationToken: '', ordering: 'DESC' });
 
   const [activeTab, setActiveTab] = React.useState(NoticesTabs.all);
@@ -76,13 +76,17 @@ export default function NoticesListPage() {
     setActiveTab(activeTab);
     switch (activeTab) {
       case NoticesTabs.all:
-        setNoticeQueryParams({});
+        setNoticeQueryParams({
+          ...noticeQueryParams,
+          registeredToMe: undefined,
+          paidByMe: undefined
+        });
         break;
       case NoticesTabs.paidByMe:
-        setNoticeQueryParams({ paidByMe: true });
+        setNoticeQueryParams({ ...noticeQueryParams, paidByMe: true, registeredToMe: undefined });
         break;
       case NoticesTabs.registeredToMe:
-        setNoticeQueryParams({ registeredToMe: true });
+        setNoticeQueryParams({ ...noticeQueryParams, registeredToMe: true, paidByMe: undefined });
     }
   };
 
@@ -181,8 +185,8 @@ export default function NoticesListPage() {
 
       <QueryLoader loaderComponent={<TransactionListSkeleton />} queryKey="noticesList">
         {(() => {
-          if (error || !data || !data.noticesList.notices) return <Retry action={refetch} />;
-          if (data.noticesList.notices?.length === 0) return <Empty />;
+          if (error || !data || !data.notices) return <Retry action={refetch} />;
+          if (data.notices?.length === 0) return <Empty />;
           return (
             <>
               <MainContent

--- a/src/routes/NoticesList/index.tsx
+++ b/src/routes/NoticesList/index.tsx
@@ -28,10 +28,20 @@ export default function NoticesListPage() {
 
   const [activeTab, setActiveTab] = React.useState(NoticesTabs.all);
   const [currentPage, setCurrentPages] = React.useState(0);
-  const [dateOrdering, setDateOrdering] = React.useState<'ASC' | 'DESC'>('DESC');
   const [pages, setPages] = React.useState(['']);
 
   const { t } = useTranslation();
+
+  console.log(
+    'activeTab',
+    activeTab,
+    'currentPage',
+    currentPage,
+    'dateOrding',
+    noticeQueryParams.ordering,
+    'pages',
+    pages
+  );
 
   const noticesList = useNormalizedNoticesList(noticeQueryParams);
 
@@ -44,14 +54,9 @@ export default function NoticesListPage() {
     setPages(['']);
   };
 
-  const resetDateOrdering = () => {
-    setDateOrdering('DESC');
-  };
-
   const toggleDateOrder = () => {
     resetPagination();
-    const newDateOrdering = dateOrdering === 'DESC' ? 'ASC' : 'DESC';
-    setDateOrdering(newDateOrdering);
+    const newDateOrdering = noticeQueryParams.ordering === 'DESC' ? 'ASC' : 'DESC';
     setNoticeQueryParams({
       ...noticeQueryParams,
       ordering: newDateOrdering,
@@ -61,21 +66,31 @@ export default function NoticesListPage() {
 
   const onTabChange = (activeTab: NoticesTabs) => {
     resetPagination();
-    resetDateOrdering();
     setActiveTab(activeTab);
     switch (activeTab) {
       case NoticesTabs.all:
         setNoticeQueryParams({
-          ...noticeQueryParams,
+          ordering: 'DESC',
+          continuationToken: '',
           registeredToMe: undefined,
           paidByMe: undefined
         });
         break;
       case NoticesTabs.paidByMe:
-        setNoticeQueryParams({ ...noticeQueryParams, paidByMe: true, registeredToMe: undefined });
+        setNoticeQueryParams({
+          ordering: 'DESC',
+          continuationToken: '',
+          paidByMe: true,
+          registeredToMe: undefined
+        });
         break;
       case NoticesTabs.registeredToMe:
-        setNoticeQueryParams({ ...noticeQueryParams, registeredToMe: true, paidByMe: undefined });
+        setNoticeQueryParams({
+          ordering: 'DESC',
+          continuationToken: '',
+          registeredToMe: true,
+          paidByMe: undefined
+        });
     }
   };
 
@@ -95,7 +110,7 @@ export default function NoticesListPage() {
       const isNewToken = !pages.find((oldToken) => oldToken === continuationToken);
       if (isNewToken) setPages([...pages, continuationToken]);
     })();
-  }, [currentPage, activeTab, dateOrdering]);
+  }, [currentPage, activeTab, noticeQueryParams.ordering]);
 
   const MainContent = ({
     all,
@@ -118,7 +133,7 @@ export default function NoticesListPage() {
               content: (
                 <TransactionsList
                   rows={all}
-                  dateOrdering={dateOrdering}
+                  dateOrdering={noticeQueryParams.ordering}
                   onDateOrderClick={toggleDateOrder}
                 />
               )
@@ -128,7 +143,7 @@ export default function NoticesListPage() {
               content: (
                 <TransactionsList
                   rows={paidByMe}
-                  dateOrdering={dateOrdering}
+                  dateOrdering={noticeQueryParams.ordering}
                   onDateOrderClick={toggleDateOrder}
                 />
               )
@@ -138,7 +153,7 @@ export default function NoticesListPage() {
               content: (
                 <TransactionsList
                   rows={registeredToMe}
-                  dateOrdering={dateOrdering}
+                  dateOrdering={noticeQueryParams.ordering}
                   onDateOrderClick={toggleDateOrder}
                 />
               )

--- a/src/utils/loaders.test.tsx
+++ b/src/utils/loaders.test.tsx
@@ -54,7 +54,7 @@ describe('api loaders', () => {
     vi.clearAllMocks();
   });
 
-  describe('transactionsApi', () => {
+  describe('Notices API', () => {
     beforeEach(() => {
       vi.clearAllMocks();
     });
@@ -63,16 +63,20 @@ describe('api loaders', () => {
       // you can generate a specific field, even if optionale, using .require()
       const dataMock = createMock(schemas.noticesListDTOSchema.required());
 
-      const apiMock = vi
-        .spyOn(utils.apiClient.notices, 'getNoticesList')
-        .mockResolvedValue({ data: dataMock } as AxiosResponse);
+      const apiMock = vi.spyOn(utils.apiClient.notices, 'getNoticesList').mockResolvedValue({
+        data: dataMock,
+        headers: {}
+      } as AxiosResponse);
 
-      const { result } = renderHook(() => loaders.getNoticesList(), { wrapper });
+      const { result } = renderHook(
+        () => loaders.getNoticesList({ ordering: 'DESC', size: 10 }, ''),
+        { wrapper }
+      );
 
       await waitFor(() => {
         expect(apiMock).toHaveBeenCalled();
         expect(result.current.isSuccess).toBeTruthy();
-        expect(result.current.data).toEqual(dataMock);
+        expect(result.current.data?.notices).toEqual(dataMock.notices);
       });
     });
 

--- a/src/utils/loaders.ts
+++ b/src/utils/loaders.ts
@@ -13,28 +13,27 @@ const parseAndLog = <T>(schema: ZodSchema, data: T, throwError: boolean = true):
   }
 };
 
-interface GetNoticesList {
+interface GetNoticesListQuery {
   /** max number of elements returned, default 10*/
-  size?: number;
+  size: number;
   paidByMe?: boolean;
   registeredToMe?: boolean;
-  continuationToken?: string;
-  ordering?: 'ASC' | 'DESC';
+  ordering: 'ASC' | 'DESC';
 }
 /**
  * Retrieve the paged notices list from arc
  */
-const getNoticesList = (query?: GetNoticesList, continuationToken?: string) =>
+const getNoticesList = (query: GetNoticesListQuery, continuationToken: string) =>
   useQuery({
     queryKey: ['noticesList'],
     queryFn: async () => {
       const { data: noticesList, headers } = await utils.apiClient.notices.getNoticesList(
         {
-          size: query?.size,
-          paidByMe: query?.paidByMe,
-          registeredToMe: query?.registeredToMe,
+          size: query.size,
+          paidByMe: query.paidByMe,
+          registeredToMe: query.registeredToMe,
           orderBy: 'TRANSACTION_DATE',
-          ordering: query?.ordering || 'DESC'
+          ordering: query.ordering
         },
         {
           headers: {
@@ -43,7 +42,10 @@ const getNoticesList = (query?: GetNoticesList, continuationToken?: string) =>
         }
       );
       parseAndLog(zodSchema.noticesListDTOSchema, noticesList);
-      return { noticesList, continuationToken: headers['x-continuation-token'] as string };
+      return {
+        notices: noticesList.notices,
+        continuationToken: headers['x-continuation-token']
+      };
     }
   });
 
@@ -62,7 +64,7 @@ const getPaymentNotices = () =>
     queryKey: ['paymentNotices'],
     queryFn: async () => {
       const { data } = await utils.apiClient.paymentNotices.getPaymentNotices({});
-      parseAndLog(zodSchema.paymentNoticesListDTOSchema, data, false);
+      parseAndLog(zodSchema.paymentNoticesListDTOSchema, data);
       return data;
     }
   });

--- a/src/utils/loaders.ts
+++ b/src/utils/loaders.ts
@@ -18,21 +18,29 @@ interface GetNoticesList {
   size?: number;
   paidByMe?: boolean;
   registeredToMe?: boolean;
+  continuationToken?: string;
 }
 /**
  * Retrieve the paged notices list from arc
  */
-const getNoticesList = (query?: GetNoticesList) =>
+const getNoticesList = (query?: GetNoticesList, continuationToken?: string) =>
   useQuery({
     queryKey: ['noticesList'],
     queryFn: async () => {
-      const { data: noticesList } = await utils.apiClient.notices.getNoticesList({
-        size: query?.size,
-        paidByMe: query?.paidByMe,
-        registeredToMe: query?.registeredToMe
-      });
+      const { data: noticesList, headers } = await utils.apiClient.notices.getNoticesList(
+        {
+          size: query?.size,
+          paidByMe: query?.paidByMe,
+          registeredToMe: query?.registeredToMe
+        },
+        {
+          headers: {
+            'x-continuation-token': continuationToken
+          }
+        }
+      );
       parseAndLog(zodSchema.noticesListDTOSchema, noticesList);
-      return noticesList;
+      return { noticesList, continuationToken: headers['x-continuation-token'] as string };
     }
   });
 

--- a/src/utils/loaders.ts
+++ b/src/utils/loaders.ts
@@ -19,6 +19,7 @@ interface GetNoticesList {
   paidByMe?: boolean;
   registeredToMe?: boolean;
   continuationToken?: string;
+  ordering?: 'ASC' | 'DESC';
 }
 /**
  * Retrieve the paged notices list from arc
@@ -31,7 +32,9 @@ const getNoticesList = (query?: GetNoticesList, continuationToken?: string) =>
         {
           size: query?.size,
           paidByMe: query?.paidByMe,
-          registeredToMe: query?.registeredToMe
+          registeredToMe: query?.registeredToMe,
+          orderBy: 'TRANSACTION_DATE',
+          ordering: query?.ordering || 'DESC'
         },
         {
           headers: {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- This PR adds pagination to the notices list and a toggle to change the order by date from ascendent to descendent and vice versa. 
- All unit tests involved were updated. 
- Some interfaces received a minor but required update.

<!--- Describe your changes in detail -->

#### Motivation and Context
We were displaying all items available because the involved API didn't allow pagination
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested automatically updating all unit tests involved and manually testing the local FE

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/21cc667c-2b0d-4a94-9b59-26e45fe499f0)


#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
