### PR TITLE
feat: [P4PU-618] Notices Alert component

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@mui/icons-material": "^5.15.15",
     "@mui/lab": "^5.0.0-alpha.170",
     "@mui/material": "^5.15.15",
-    "@pagopa/mui-italia": "^1.3.0",
+    "@pagopa/mui-italia": "^1.5.1-0",
     "@preact/signals-react": "^2.2.0",
     "@tanstack/react-query": "^5.40.0",
     "axios": "^1.6.8",

--- a/src/components/Alerts/Alert.test.tsx
+++ b/src/components/Alerts/Alert.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Alert } from './Alert';
+import { InfoAlertProps } from './Alert';
+import React from 'react';
+
+// Mock action data
+const action = {
+  href: 'https://example.com',
+  message: 'Learn more'
+};
+
+// Define a function to render the component with props
+const renderComponent = (props?: Partial<InfoAlertProps>) => {
+  return render(<Alert message="This is an info alert." action={action} {...props} />);
+};
+
+it('renders the message and action link correctly', () => {
+  renderComponent();
+  expect(screen.getByText('This is an info alert.')).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: 'Learn more' })).toHaveAttribute(
+    'href',
+    'https://example.com'
+  );
+});
+
+it('applies the correct severity and variant', () => {
+  renderComponent({ severity: 'warning', variant: 'filled' });
+  const alert = screen.getByRole('alert');
+
+  expect(alert).toHaveClass('MuiAlert-colorWarning');
+  expect(alert).toHaveClass('MuiAlert-filled');
+});
+
+it('opens the action link in a new tab', () => {
+  renderComponent();
+  const actionLink = screen.getByRole('link', { name: 'Learn more' });
+
+  expect(actionLink).toHaveAttribute('target', '_blank');
+});

--- a/src/components/Alerts/Alert.tsx
+++ b/src/components/Alerts/Alert.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Alert as MuiAlert, AlertProps, Typography } from '@mui/material';
+import { ButtonNaked } from '@pagopa/mui-italia';
+
+export type InfoAlertProps = {
+  variant?: AlertProps['variant'];
+  severity?: AlertProps['severity'];
+  message: string;
+  action: {
+    href: string;
+    message: string;
+  };
+};
+
+export const Alert = ({
+  message,
+  action,
+  variant = 'outlined',
+  severity = 'info'
+}: InfoAlertProps) => (
+  <MuiAlert
+    severity={severity}
+    variant={variant}
+    sx={{
+      '& .MuiAlert-message': {
+        display: 'flex',
+        flexDirection: { xs: 'column', md: 'row' },
+        alignItems: { xs: 'flex-start', md: 'center' },
+        gap: 1,
+        justifyContent: 'space-between'
+      }
+    }}>
+    <Typography variant="body2" width="80%">
+      {message}
+    </Typography>
+    <ButtonNaked color="primary" href={action.href} target="_blank">
+      {action.message}
+    </ButtonNaked>
+  </MuiAlert>
+);

--- a/src/routes/PaymentNotices/index.tsx
+++ b/src/routes/PaymentNotices/index.tsx
@@ -9,10 +9,13 @@ import { useTranslation } from 'react-i18next';
 import { useStore } from 'store/GlobalStore';
 import { STATE } from 'store/types';
 import utils from 'utils';
+import { Alert } from 'components/Alerts/Alert';
 
 const Notices = () => {
   const { data, isError, refetch } = useNormalizedNotices();
   const { setState } = useStore();
+
+  const { t } = useTranslation();
 
   useEffect(() => {
     setState(STATE.PAYMENT_NOTICE, {});
@@ -23,6 +26,13 @@ const Notices = () => {
     if (!data?.paymentNotices?.length) return <PaymentNotice.Empty />;
     return (
       <Stack gap={5} component="section">
+        <Alert
+          message={t('app.paymentNotices.noticesAlert.info')}
+          action={{
+            href: utils.config.checkoutHost,
+            message: t('app.paymentNotices.noticesAlert.action')
+          }}
+        />
         <PaymentNotice.List paymentNotices={data.paymentNotices} />
         <PaymentNotice.Info />
       </Stack>

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -109,6 +109,10 @@
         "info": "Gli avvisi sono stati recuperati dagli archivi degli enti creditori aderenti al servizio.",
         "action": "Segnala un problema"
       },
+      "noticesAlert": {
+        "info": "Questi sono gli avvisi di pagamento che gli enti hanno comunicato a PagoPA. Se non trovi un avviso, rivolgiti all’Ente Creditore oppure premi su ‘Paga un avviso’ e inserisci i dati.",
+        "action": "Paga un avviso"
+        },
       "optin": {
         "title": "Consenti a PagoPA di ricercare i tuoi avvisi?",
         "body": "Se confermi, consenti a PagoPA di ricercare gli avvisi di pagamento a tuo nome tra gli archivi degli enti aderenti al servizio.",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3071,9 +3071,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pagopa/mui-italia@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "@pagopa/mui-italia@npm:1.3.0"
+"@pagopa/mui-italia@npm:^1.5.1-0":
+  version: 1.5.1-0
+  resolution: "@pagopa/mui-italia@npm:1.5.1-0"
   dependencies:
     "@fontsource/dm-mono": "npm:^4.5.10"
     "@fontsource/titillium-web": "npm:^4.5.9"
@@ -3083,7 +3083,7 @@ __metadata:
   peerDependencies:
     react: ^18.2.0
     react-dom: ^18.2.0
-  checksum: 10c0/06fa346c41a8425346ac5d85e964a69f2703c24ed93ac81c8b8363d380b3134e6373430510c348214c3b4a66e2915420a9fe4ec949ce8352edae99274cbeeb70
+  checksum: 10c0/8132dd366b05c233643210bb7080ae6fa961900fb141b450abfd975d41efb0fc862e54c03022b933f452ef3c038ee4c4b812a6bf5aec75ba6ba7663f1fc1def0
   languageName: node
   linkType: hard
 
@@ -12335,7 +12335,7 @@ __metadata:
     "@mui/icons-material": "npm:^5.15.15"
     "@mui/lab": "npm:^5.0.0-alpha.170"
     "@mui/material": "npm:^5.15.15"
-    "@pagopa/mui-italia": "npm:^1.3.0"
+    "@pagopa/mui-italia": "npm:^1.5.1-0"
     "@preact/signals-react": "npm:^2.2.0"
     "@storybook/addon-essentials": "npm:8.1.11"
     "@storybook/addon-interactions": "npm:8.1.11"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- updates mui-italia dependency
- adds Alert component
- add an InfoAlert for the PaymentNotices
- adds required strings to the it langmap
- unit tests

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Adds a previously missing alert as specified from requirements. Creates a generic Alert component with updated style from the design requirements

#### How Has This Been Tested?
- visual testing
- unit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/7942be86-2f8a-4e11-94e9-a6c4e7f46ae7)
![image](https://github.com/user-attachments/assets/d5e751ad-e42c-4a6f-99db-21a232889135)

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
