### PR TITLE
ci: [P4PU-695] using dedicated .env file instead of using environments

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@ ENTITIES_LOGO_CDN="https://assets.cdn.io.italia.it/logos/organizations"
 CHECKOUT_HOST="https://dev.checkout.pagopa.it"
 LOGIN_URL="https://api.dev.cittadini.pagopa.it/arc/v1/login/oneidentity"
 CHECKOUT_PLATFORM_URL="https://api.dev.platform.pagopa.it/checkout/ec/v1"
-VERSION="test"
+VERSION="localhost"
 # This url is used as the single return address after completing a PaymentNotice transaction on the checkout platform.
 # TODO: Update this logic to support different return URLs based on various payment outcomes (e.g., success, failure, cancellation).
 PAYMENT_RETURN_URL="http://localhost:1234"

--- a/.env.dev
+++ b/.env.dev
@@ -1,0 +1,11 @@
+APIHOST="https://api.dev.cittadini.pagopa.it/arc/v1"
+ENTITIES_LOGO_CDN="https://assets.cdn.io.italia.it/logos/organizations"
+CHECKOUT_HOST="https://dev.checkout.pagopa.it"
+LOGIN_URL="https://api.dev.cittadini.pagopa.it/arc/v1/login/oneidentity"
+CHECKOUT_PLATFORM_URL="https://api.dev.platform.pagopa.it/checkout/ec/v1"
+VERSION="test"
+# This url is used as the single return address after completing a PaymentNotice transaction on the checkout platform.
+# TODO: Update this logic to support different return URLs based on various payment outcomes (e.g., success, failure, cancellation).
+PAYMENT_RETURN_URL="http://localhost:1234"
+# Cause our webapp will served in a subpath of a domain
+DEPLOY_PATH="/pagamenti"

--- a/.env.dev
+++ b/.env.dev
@@ -3,7 +3,6 @@ ENTITIES_LOGO_CDN="https://assets.cdn.io.italia.it/logos/organizations"
 CHECKOUT_HOST="https://dev.checkout.pagopa.it"
 LOGIN_URL="https://api.dev.cittadini.pagopa.it/arc/v1/login/oneidentity"
 CHECKOUT_PLATFORM_URL="https://api.dev.platform.pagopa.it/checkout/ec/v1"
-VERSION="test"
 # This url is used as the single return address after completing a PaymentNotice transaction on the checkout platform.
 # TODO: Update this logic to support different return URLs based on various payment outcomes (e.g., success, failure, cancellation).
 PAYMENT_RETURN_URL="http://localhost:1234"

--- a/.env.test
+++ b/.env.test
@@ -5,7 +5,6 @@ ENTITIES_LOGO_CDN="https://assets.cdn.io.italia.it/logos/organizations"
 CHECKOUT_HOST="https://dev.checkout.pagopa.it"
 LOGIN_URL="https://api.dev.cittadini.pagopa.it/arc/v1/login/oneidentity"
 CHECKOUT_PLATFORM_URL="https://api.dev.platform.pagopa.it/checkout/ec/v1"
-VERSION="test"
 # This url is used as the single return address after completing a PaymentNotice transaction on the checkout platform.
 # TODO: Update this logic to support different return URLs based on various payment outcomes (e.g., success, failure, cancellation).
 PAYMENT_RETURN_URL="http://localhost:1234"

--- a/.env.uat
+++ b/.env.uat
@@ -3,7 +3,6 @@ ENTITIES_LOGO_CDN="https://assets.cdn.io.italia.it/logos/organizations"
 CHECKOUT_HOST="https://uat.checkout.pagopa.it"
 LOGIN_URL="https://api.uat.cittadini.pagopa.it/arc/v1/login/oneidentity"
 CHECKOUT_PLATFORM_URL="https://api.uat.platform.pagopa.it/checkout/ec/v1"
-VERSION="test"
 # This url is used as the single return address after completing a PaymentNotice transaction on the checkout platform.
 # TODO: Update this logic to support different return URLs based on various payment outcomes (e.g., success, failure, cancellation).
 PAYMENT_RETURN_URL="http://localhost:1234"

--- a/.env.uat
+++ b/.env.uat
@@ -1,0 +1,11 @@
+APIHOST="https://api.uat.cittadini.pagopa.it/arc/v1"
+ENTITIES_LOGO_CDN="https://assets.cdn.io.italia.it/logos/organizations"
+CHECKOUT_HOST="https://uat.checkout.pagopa.it"
+LOGIN_URL="https://api.uat.cittadini.pagopa.it/arc/v1/login/oneidentity"
+CHECKOUT_PLATFORM_URL="https://api.uat.platform.pagopa.it/checkout/ec/v1"
+VERSION="test"
+# This url is used as the single return address after completing a PaymentNotice transaction on the checkout platform.
+# TODO: Update this logic to support different return URLs based on various payment outcomes (e.g., success, failure, cancellation).
+PAYMENT_RETURN_URL="http://localhost:1234"
+# Cause our webapp will served in a subpath of a domain
+DEPLOY_PATH="/pagamenti"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,10 @@ env:
 jobs:
   testing-e2e:
     runs-on: ubuntu-latest
-    environment: ${{ github.base_ref == 'uat' && 'uat' || 'dev' }}
+# unfortunately using environment implies a deployment
+# this is a problem for us, read the following for more info
+# https://github.com/actions/runner/issues/2120    
+#    environment: ${{ github.base_ref == 'uat' && 'uat' || 'dev' }}
   
     steps:
       - name: Set up Node.js
@@ -20,22 +23,30 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: fe
-      
-      - name: populate environment vars writing down an .env file
+
+      - name: populate environment vars using a specific .env.ENVIRONMENT FILE
         run: |
           rm .env
-          touch .env
-          echo APIHOST=${{ vars.API_HOST }} >> .env
-          echo ENV=test >> .env
-          echo ENTITIES_LOGO_CDN=https://assets.cdn.io.italia.it/logos/organizations >> .env
-          echo CHECKOUT_HOST=${{ vars.CHECKOUT_HOST }} >> .env
-          echo LOGIN_URL=${{ vars.LOGIN_URL }} >> .env
-          echo CHECKOUT_PLATFORM_URL=${{ vars.CHECKOUT_PLATFORM_URL }} >> .env
-          echo PAYMENT_RETURN_URL=http://localhost:1234 >> .env
-          echo DEPLOY_PATH=/pagamenti >> .env
+          mv .env.${{ github.base_ref == 'uat' && 'uat' || 'dev' }} .env
           echo VERSION=${{ github.sha }} >> .env
           cat .env
         working-directory: fe
+
+#      - name: populate environment vars writing down an .env file
+#        run: |
+#          rm .env
+#          touch .env
+#          echo APIHOST=${{ vars.API_HOST }} >> .env
+#          echo ENV=test >> .env
+#          echo ENTITIES_LOGO_CDN=https://assets.cdn.io.italia.it/logos/organizations >> .env
+#          echo CHECKOUT_HOST=${{ vars.CHECKOUT_HOST }} >> .env
+#          echo LOGIN_URL=${{ vars.LOGIN_URL }} >> .env
+#          echo CHECKOUT_PLATFORM_URL=${{ vars.CHECKOUT_PLATFORM_URL }} >> .env
+#          echo PAYMENT_RETURN_URL=http://localhost:1234 >> .env
+#          echo DEPLOY_PATH=/pagamenti >> .env
+#          echo VERSION=${{ github.sha }} >> .env
+#          cat .env
+#        working-directory: fe
   
       - name: Install fe dependecies
         run: yarn install

--- a/.identity/99_locals.tf
+++ b/.identity/99_locals.tf
@@ -7,19 +7,13 @@ locals {
 
   repo_secrets = var.env_short == "p" ? {
     SONAR_TOKEN = data.azurerm_key_vault_secret.sonar_token[0].value
-  } : {}
-
-  env_variables = contains(["d", "u"], var.env_short) ? {
-    API_HOST              = "https://api.${var.env}.cittadini.pagopa.it/arc/v1"
-    CHECKOUT_HOST         = "https://${var.env}.checkout.pagopa.it"
-    CHECKOUT_PLATFORM_URL = "https://api.${var.env}.platform.pagopa.it/checkout/ec/v1"
-    LOGIN_URL             = "https://api.${var.env}.cittadini.pagopa.it/arc/v1/login/oneidentity"
-  } : {}
-
-  env_secrets = {
     E2E_USERNAME = try(data.azurerm_key_vault_secret.username_test[0].value, "")
     E2E_PASSWORD = try(data.azurerm_key_vault_secret.password_test[0].value, "")
-  }
+  } : {}
+
+  env_variables = contains(["d", "u"], var.env_short) ? {} : {}
+
+  env_secrets = contains(["d", "u"], var.env_short) ? {} : {}
 
   map_repo = {
     "dev" : "*",

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ The table below describes all the Environment variables needed by the applicatio
 | Variable name     | Description                                           | type                          |
 | ----------------- | ----------------------------------------------------- | ----------------------------- |
 | APIHOST           | api service host                                      | url                           |
-| ENV               | environment id                                        | "LOCAL", "DEV", "UAT", "PROD" |
 | ASSISTANCE_LINK   | Link for assistance page                              | url                           |
 | ENTITIES_LOGO_CDN | cdn link for logos                                    | url                           |
 | LOGIN_URL         | Link for login button                                 | url                           |

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -14,7 +14,6 @@ describe('Configuration Tests', () => {
 
   it('should load configuration with valid environment variables', async () => {
     process.env.APIHOST = 'http://localhost:1234/api';
-    process.env.ENV = 'DEV';
     process.env.CHECKOUT_HOST = 'https://dev.checkout.pagopa.it';
     process.env.LOGIN_URL = 'https://api.dev.cittadini-p4pa.pagopa.it/arc/v1/login/oneidentity';
     process.env.CHECKOUT_PLATFORM_URL = 'https://api.dev.platform.pagopa.it/checkout/ec/v1';
@@ -26,7 +25,6 @@ describe('Configuration Tests', () => {
     const reloadedConfig = (await import('./config')).default;
 
     // Assertions to ensure the config values are correctly loaded
-    expect(reloadedConfig.env).toBe('DEV');
     expect(reloadedConfig.baseURL).toBe(process.env.APIHOST);
     expect(reloadedConfig.checkoutHost).toBe(process.env.CHECKOUT_HOST);
     expect(reloadedConfig.loginUrl).toBe(process.env.LOGIN_URL);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -5,7 +5,6 @@ import { z, ZodError } from 'zod';
 /** APIHOST default value works in conjunction with the proxy server. See the .proxyrc file */
 const {
   APIHOST = 'http://localhost:1234/api',
-  ENV = 'LOCAL',
   ENTITIES_LOGO_CDN,
   CHECKOUT_HOST = 'https://dev.checkout.pagopa.it',
   LOGIN_URL = 'https://api.dev.cittadini-p4pa.pagopa.it/arc/v1/login/oneidentity',
@@ -15,10 +14,7 @@ const {
   VERSION = ''
 } = process.env;
 
-type ENVIRONMENT = 'LOCAL' | 'DEV' | 'UAT' | 'PROD';
-
 // ENV variables validation
-const ENV_Schema: z.ZodType<ENVIRONMENT> = z.enum(['LOCAL', 'DEV', 'UAT', 'PROD']);
 const VERSION_schema = z.string();
 const APIHOST_schema = z.string().url();
 const ENTITIES_LOGO_CDN_schema = z.string().url();
@@ -28,7 +24,6 @@ const CHECKOUT_PLATFORM_URL_schema = z.string().url();
 const PAYMENT_RETURN_URL_schema = z.string().url();
 const DEPLOY_PATH_schema = z.string();
 try {
-  ENV_Schema.parse(process.env.ENV);
   APIHOST_schema.parse(process.env.APIHOST);
   ENTITIES_LOGO_CDN_schema.parse(process.env.ENTITIES_LOGO_CDN);
   CHECKOUT_HOST_schema.parse(process.env.CHECKOUT_HOST);
@@ -42,7 +37,6 @@ try {
 }
 
 type Config = {
-  env: ENVIRONMENT;
   version: string;
   baseURL: string;
   pagopaLink: RootLinkType;
@@ -67,8 +61,6 @@ const pagopaLink: RootLinkType = {
 };
 
 const config: Config = {
-  /** Running environment, usually valued by pipelines */
-  env: ENV as ENVIRONMENT,
   /** Running version, usually valued by pipelines */
   version: VERSION,
   /** the prefix of all api calls


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- environment removed from e2e.yml action
- using repository secretes instead of environment secrets (E2E_USERNAME, E2E_PASSWORD)
- added a .env.dev file to execute E2E tests pointing at DEV environment
- added a .env.uat file to execute E2E tests pointing at UAT environment

<!--- Describe your changes in detail -->

#### Motivation and Context

using github environments implies a deployment. This is not the case: the E2E test action does not perform any deployment or environment updates. For this reason I preferred not to use environments, at least until the problem is resolved on the github side. For more info: https://github.com/actions/runner/issues/2120

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

In the checks section below, the E2E test step is executed correctly and no deployment is added

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
