### PR TITLE
fix: [P4PU-666] Drop back button on assistance form

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,11 +81,7 @@ const router = createBrowserRouter([
             element: <Assistance />,
             errorElement: <ErrorFallback />,
             handle: {
-              backButton: true,
-              backButtonText: 'exit',
-              backButtonFunction: () => {
-                utils.modal.open(utils.modal.ModalId.ASSISTANCEBACK);
-              },
+              backButton: false,
               sidebar: {
                 visibile: false
               }

--- a/src/components/AssistanceForm/AssistanceForm.tsx
+++ b/src/components/AssistanceForm/AssistanceForm.tsx
@@ -11,7 +11,6 @@ import {
   Box
 } from '@mui/material';
 import { Trans, useTranslation } from 'react-i18next';
-import { ArrowBack } from '@mui/icons-material';
 import utils from 'utils';
 import { zendeskAssistanceTokenResponseSchema } from '../../../generated/zod-schema';
 
@@ -144,14 +143,6 @@ export const AssistanceForm = () => {
             />
           </Typography>
           <Stack direction={'row'} justifyContent={'space-between'}>
-            <Button
-              variant="outlined"
-              size="large"
-              color="primary"
-              startIcon={<ArrowBack />}
-              onClick={() => utils.modal.open(utils.modal.ModalId.ASSISTANCEBACK)}>
-              {t('app.routes.exit')}
-            </Button>
             <Button
               type="submit"
               data-testid="assistance-confirm-button"


### PR DESCRIPTION
This PR drops the back button on the Assistance form page.

#### List of Changes
- remove back link from route setting
- remove button from the page

#### Motivation and Context
Solve the request

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
