### PR TITLE
feat: [P4PU-747] payment notices, no data feedback updated

### DIFF
--- a/src/components/Transactions/NoData.test.tsx
+++ b/src/components/Transactions/NoData.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import NoData from './NoData';
+import '@testing-library/jest-dom';
+
+describe('NoData component', () => {
+  it('renders without crashing', () => {
+    render(<NoData title="title" text="text" />);
+  });
+
+  it('renders texts passed as props correctly', () => {
+    render(<NoData title="title" text="text" />);
+    expect(screen.getByText('title')).toBeInTheDocument();
+    expect(screen.getByText('text')).toBeInTheDocument();
+  });
+});

--- a/src/components/Transactions/NoData.tsx
+++ b/src/components/Transactions/NoData.tsx
@@ -1,17 +1,26 @@
 import React from 'react';
-import { Typography } from '@mui/material';
-import { useTranslation } from 'react-i18next';
+import { Typography, Paper } from '@mui/material';
 
-const NoData = () => {
-  const { t } = useTranslation();
+const NoData = (props: { title: string; text: string }) => {
+  const { title, text } = props;
   return (
-    <Typography
-      variant="body2"
-      fontWeight={600}
-      data-testid="app.paymentNotice.filtered.noData"
-      textAlign="center">
-      {t('app.paymentNotice.filtered.noData')}
-    </Typography>
+    <Paper elevation={0} sx={{ margin: '4px', padding: 2 }}>
+      <Typography
+        mb={2}
+        variant="body2"
+        fontWeight={600}
+        data-testid="app.paymentNotice.filtered.noData"
+        textAlign="center">
+        {title}
+      </Typography>
+      <Typography
+        variant="body2"
+        fontWeight={400}
+        data-testid="app.paymentNotice.filtered.noData"
+        textAlign="center">
+        {text}
+      </Typography>
+    </Paper>
   );
 };
 

--- a/src/routes/NoticesList/NoticesList.test.tsx
+++ b/src/routes/NoticesList/NoticesList.test.tsx
@@ -6,6 +6,7 @@ import { useMediaQuery } from '@mui/material';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Mock } from 'vitest';
 import loaders from 'utils/loaders';
+import translation from '../../translations/it/translations.json';
 
 const queryClient = new QueryClient();
 
@@ -290,5 +291,83 @@ describe('NoticesListRoute', () => {
       expect(next).toBeInTheDocument();
       expect(next).toBeDisabled();
     });
+  });
+
+  it('it renders a proper feedback when empty filtered(paidByMe) items are returned', async () => {
+    (loaders.getNoticesList as Mock).mockReturnValue({
+      data: {
+        notices: mockNotices,
+        continuationToken: '0001'
+      },
+      isError: false
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <NoticesList />
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(loaders.getNoticesList).toHaveBeenCalled();
+    });
+
+    (loaders.getNoticesList as Mock).mockReturnValue({
+      data: {
+        notices: [],
+        continuationToken: ''
+      },
+      isError: false
+    });
+
+    fireEvent.click(screen.getByText('app.transactions.paidByMe'));
+    await waitFor(() => {
+      expect(loaders.getNoticesList).toHaveBeenCalled();
+    });
+
+    expect(
+      screen.getByText('app.paymentNotice.filtered.nodata.paidByMe.title')
+    ).toBeInTheDocument();
+    expect(screen.getByText('app.paymentNotice.filtered.nodata.paidByMe.text')).toBeInTheDocument();
+  });
+
+  it('it renders a proper feedback when empty filtered(ownedByMe) items are returned', async () => {
+    (loaders.getNoticesList as Mock).mockReturnValue({
+      data: {
+        notices: mockNotices,
+        continuationToken: '0001'
+      },
+      isError: false
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <NoticesList />
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(loaders.getNoticesList).toHaveBeenCalled();
+    });
+
+    (loaders.getNoticesList as Mock).mockReturnValue({
+      data: {
+        notices: [],
+        continuationToken: ''
+      },
+      isError: false
+    });
+
+    fireEvent.click(screen.getByText('app.transactions.ownedByMe'));
+    await waitFor(() => {
+      expect(loaders.getNoticesList).toHaveBeenCalled();
+    });
+
+    expect(
+      screen.getByText('app.paymentNotice.filtered.nodata.ownedByMe.title')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('app.paymentNotice.filtered.nodata.ownedByMe.title')
+    ).toBeInTheDocument();
   });
 });

--- a/src/routes/NoticesList/NoticesList.test.tsx
+++ b/src/routes/NoticesList/NoticesList.test.tsx
@@ -6,7 +6,6 @@ import { useMediaQuery } from '@mui/material';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Mock } from 'vitest';
 import loaders from 'utils/loaders';
-import translation from '../../translations/it/translations.json';
 
 const queryClient = new QueryClient();
 

--- a/src/routes/NoticesList/index.tsx
+++ b/src/routes/NoticesList/index.tsx
@@ -141,7 +141,10 @@ export default function NoticesListPage() {
                   onDateOrderClick={toggleDateOrder}
                 />
               ) : (
-                <NoData />
+                <NoData
+                  title={t('app.paymentNotice.filtered.nodata.paidByMe.title')}
+                  text={t('app.paymentNotice.filtered.nodata.paidByMe.text')}
+                />
               )
             },
             {
@@ -153,7 +156,10 @@ export default function NoticesListPage() {
                   onDateOrderClick={toggleDateOrder}
                 />
               ) : (
-                <NoData />
+                <NoData
+                  title={t('app.paymentNotice.filtered.nodata.ownedByMe.title')}
+                  text={t('app.paymentNotice.filtered.nodata.ownedByMe.text')}
+                />
               )
             }
           ]}

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -51,7 +51,7 @@
     },
     "transactions": {
       "all": "Tutte",
-      "paidByMe": "Pagate da me",
+      "paidByMe": "Pagate con IO",
       "ownedByMe": "Intestate a me",
       "searchByName": "Cerca per nome",
       "searchBy": "Cerca per",
@@ -87,8 +87,15 @@
         "description": "Se hai ricevuto un avviso pagoPA, premi su ‘Paga un avviso’ e inserisci i dati.",
         "button": "Paga un avviso"
       },
-      "filtered": {
-        "noData": "Nessun dato"
+      "filtered.nodata": {
+        "paidByMe": {
+          "title": "Qui vedrai le ricevute dei pagamenti fatti con l’app IO",
+          "text": "Se hai pagato con un altro canale, per ottenere la ricevuta rivolgiti all’ente creditore."
+        },
+        "ownedByMe": {
+          "title": "Qui vedrai le ricevute dei pagamenti intestati a te",
+          "text": "Se non torvi una ricevuta, rivolgiti all’ente creditore."
+        }
       },
       "error": {
         "description": "Non riusciamo a recuperare i dati a causa di un problema.",


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- translation file (it) updated
- NoData component updated (prop title and text added)

<!--- Describe your changes in detail -->

#### Motivation and Context
Design has changed and consequentially an updated to the codebase is required

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested manually mocking the response from the /notices API (to have an empty notices array as result) and inspecting the output with the design

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/c69faa1d-953b-4aca-84ec-aaef1aaa59d6)

![image](https://github.com/user-attachments/assets/d9cc32cf-b2c3-44b2-b17d-7221847a82f3)

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
