### PR TITLE
fix: [P4PU-949] add language support for date formatting in PaymentNotice component

### DIFF
--- a/src/components/PaymentNotice/List.tsx
+++ b/src/components/PaymentNotice/List.tsx
@@ -3,8 +3,9 @@ import Typography from '@mui/material/Typography';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { PaymentNotice } from './PaymentNotice';
-import { DateFormat, datetools } from 'utils/datetools';
+import { DateFormat, datetools, langToLocale } from 'utils/datetools';
 import { PaymentNoticeType } from 'models/PaymentNotice';
+import { useLanguage } from 'hooks/useLanguage';
 
 /**
  * This component is considered private and should not be used directly.
@@ -18,6 +19,7 @@ export const _List = ({ paymentNotices }: { paymentNotices: PaymentNoticeType[] 
   const { t } = useTranslation();
   const updatedDate = new Date().toISOString();
   document.body.style.overflow = 'auto';
+  const { language } = useLanguage() as { language: keyof typeof langToLocale };
 
   return (
     <Stack gap={3}>
@@ -38,7 +40,8 @@ export const _List = ({ paymentNotices }: { paymentNotices: PaymentNoticeType[] 
             {datetools.formatDate(updatedDate, {
               format: DateFormat.LONG,
               withTime: true,
-              timeZone: datetools.localTimeZone
+              timeZone: datetools.localTimeZone,
+              locale: langToLocale[language]
             })}
           </Typography>
         </Typography>

--- a/src/utils/datetools.ts
+++ b/src/utils/datetools.ts
@@ -3,6 +3,11 @@ export enum DateFormat {
   MEDIUM = 'medium'
 }
 
+export enum langToLocale {
+  it = 'it-IT',
+  en = 'en-US'
+}
+
 interface FormatDateOptions extends Intl.DateTimeFormatOptions {
   withTime?: boolean;
   format?: DateFormat;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
This change allows the extended date to be translated in the "Payment Notice List Page":
- added a langToLocale enum in date tools module
- passing the right locale by language in "Payment Notice List Page" to the formatDate method

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change is required to have a fully translated application 
#### How Has This Been Tested?
Has been tested switching between Italian and English language (from the select in the footer) and inspecting the FE 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
