### PR TITLE
fix: [P4PU-970] update CourtesyPage routing and error handling to use useParams instead of useLoaderData

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,7 +70,7 @@ const router = createBrowserRouter([
         )
       },
       {
-        path: ArcRoutes.COURTESY_PAGE.replace(':error', ''),
+        path: ArcRoutes.COURTESY_PAGE,
         element: (
           <PreLoginLayout>
             <CourtesyPage />
@@ -164,17 +164,7 @@ const router = createBrowserRouter([
                   }
                 }
               ]
-            : []),
-          {
-            path: ArcRoutes.COURTESY_PAGE,
-            loader: ({ params }) => Promise.resolve(params.error),
-            element: <CourtesyPage />,
-            handle: {
-              sidebar: {
-                visibile: false
-              }
-            }
-          }
+            : [])
         ]
       }
     ]

--- a/src/routes/CourtesyPage/CourtesyPage.test.tsx
+++ b/src/routes/CourtesyPage/CourtesyPage.test.tsx
@@ -14,7 +14,7 @@ vi.mock('react-router-dom', () => ({
       get: () => '403'
     }
   ],
-  useLoaderData: vi.fn(),
+  useParams: vi.fn(),
   Link: vi.fn()
 }));
 

--- a/src/routes/CourtesyPage/index.tsx
+++ b/src/routes/CourtesyPage/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button, Typography, Container, Box } from '@mui/material';
-import { Link, useLoaderData } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Helmet } from 'react-helmet';
 import { ArcErrors, ArcRoutes } from '../../routes/routes';
@@ -27,7 +27,7 @@ export const ErrorIconComponent: React.FC<ErrorIconComponentProps> = ({ erroCode
 
 export const CourtesyPage = () => {
   const { t } = useTranslation();
-  const errorDesc = useLoaderData() as keyof typeof ArcErrors;
+  const errorDesc = useParams()?.error as keyof typeof ArcErrors;
   const errorCode = ArcErrors[errorDesc];
 
   return (


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Update CourtesyPage routing and error handling to use useParams instead of useLoaderData

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This fix a bug that was causing an infinte redirect loop on courtesy page
#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
