### PR TITLE
fix: [P4PU-971] copyToClipBoard icon color fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@mui/icons-material": "^5.15.15",
     "@mui/lab": "^5.0.0-alpha.170",
     "@mui/material": "^5.15.15",
-    "@pagopa/mui-italia": "^1.5.3",
+    "@pagopa/mui-italia": "^1.6.1",
     "@preact/signals-react": "^2.2.0",
     "@tanstack/react-query": "^5.40.0",
     "axios": "^1.6.8",

--- a/src/components/PaymentNotice/Detail.tsx
+++ b/src/components/PaymentNotice/Detail.tsx
@@ -196,7 +196,11 @@ export const _Detail = ({ paymentNotice }: { paymentNotice: PaymentNoticeDetails
                     </Grid>
                     <Divider />
                     <Grid container justifyContent={'space-between'}>
-                      <Grid item component={'dl'} data-testid="app.paymentNoticeDetail.iuv">
+                      <Grid
+                        item
+                        component={'dl'}
+                        data-testid="app.paymentNoticeDetail.iuv"
+                        alignItems={'center'}>
                         <Typography
                           sx={{ wordBreak: 'break-word' }}
                           component="dt"
@@ -211,11 +215,7 @@ export const _Detail = ({ paymentNotice }: { paymentNotice: PaymentNoticeDetails
                           {paymentNotice.paymentOptions.iuv}
                         </Typography>
                       </Grid>
-                      <Grid item></Grid>
-                      <CopyToClipboardButton
-                        value={paymentNotice.paymentOptions.iuv}
-                        color="primary"
-                      />
+                      <CopyToClipboardButton value={paymentNotice.paymentOptions.iuv} />
                     </Grid>
                     <Divider />
 
@@ -239,7 +239,7 @@ export const _Detail = ({ paymentNotice }: { paymentNotice: PaymentNoticeDetails
                         </Typography>
                       </Grid>
                       <Grid item>
-                        <CopyToClipboardButton value={paymentNotice.paTaxCode} color="primary" />
+                        <CopyToClipboardButton value={paymentNotice.paTaxCode} />
                       </Grid>
                     </Grid>
                   </Stack>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -115,7 +115,7 @@ export const Sidebar: React.FC = () => {
                   aria-label={t(!collapsed ? 'sidebar.collapse' : 'sidebar.expand')}
                   onClick={() => changeMenuState()}
                   size="large">
-                  <MenuIcon />
+                  <MenuIcon color="action" />
                   {!lg && (
                     <Typography variant="button" sx={styles.hamburgerTypography}>
                       {t('menu.menu')}

--- a/src/components/Transactions/TransactionDetail.tsx
+++ b/src/components/Transactions/TransactionDetail.tsx
@@ -362,10 +362,7 @@ export default function TransactionDetail({ noticeData }: { noticeData: NoticeDe
                       </Typography>
                     </Grid>
                     <Grid item xs={2} paddingTop={1} textAlign={'end'}>
-                      <CopyToClipboardButton
-                        value={noticeData.authCode.toString()}
-                        color="primary"
-                      />
+                      <CopyToClipboardButton value={noticeData.authCode.toString()} />
                     </Grid>
                   </Grid>
                   <Divider />
@@ -392,10 +389,7 @@ export default function TransactionDetail({ noticeData }: { noticeData: NoticeDe
                       </Stack>
                     </Grid>
                     <Grid item xs={2} paddingTop={1} textAlign={'end'}>
-                      <CopyToClipboardButton
-                        value={noticeData.eventId.toString()}
-                        color="primary"
-                      />
+                      <CopyToClipboardButton value={noticeData.eventId.toString()} />
                     </Grid>
                   </Grid>
                 </Stack>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3426,9 +3426,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pagopa/mui-italia@npm:^1.5.3":
-  version: 1.5.3
-  resolution: "@pagopa/mui-italia@npm:1.5.3"
+"@pagopa/mui-italia@npm:^1.6.1":
+  version: 1.6.1
+  resolution: "@pagopa/mui-italia@npm:1.6.1"
   dependencies:
     "@fontsource/dm-mono": "npm:^4.5.10"
     "@fontsource/titillium-web": "npm:^4.5.9"
@@ -3438,7 +3438,7 @@ __metadata:
   peerDependencies:
     react: ^18.2.0
     react-dom: ^18.2.0
-  checksum: 10c0/a82781892cbd4112c5397694f663881a14a56b742d51ca7cb6b98c35ff88baec05637a01ee86600962fff27729eb3e2e7abd5d75ae38adab53c0dec2f1d11724
+  checksum: 10c0/6955adfc4e6ef1c4f6a795ae759ebbd09c28fc6fe258f5d1872d9e77762af50bdd6dd8e027635060320d5fa0e4f6cc77e12fad37d3331d65bd3e6c7377e7345b
   languageName: node
   linkType: hard
 
@@ -14348,7 +14348,7 @@ __metadata:
     "@mui/icons-material": "npm:^5.15.15"
     "@mui/lab": "npm:^5.0.0-alpha.170"
     "@mui/material": "npm:^5.15.15"
-    "@pagopa/mui-italia": "npm:^1.5.3"
+    "@pagopa/mui-italia": "npm:^1.6.1"
     "@preact/signals-react": "npm:^2.2.0"
     "@storybook/addon-essentials": "npm:8.1.11"
     "@storybook/addon-interactions": "npm:8.1.11"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- @pagopa/mui-italia dependecy updated from 1.5.3 to 1.6.1 version
- color fixed and aligned to the design in CopyToClipboardButton component

<!--- Describe your changes in detail -->

#### Motivation and Context
This is required because a previous mui-italia dependency update caused an wrong color visualization for some icons
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested by manual visual inspection
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/0b38a0c5-8f00-41e4-b813-b40c6f6c273c)

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
